### PR TITLE
Fix missing args variable error in JS renderer

### DIFF
--- a/packages/renderers-js/src/fragments/instructionFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionFunction.ts
@@ -1,4 +1,4 @@
-import { camelCase, InstructionNode, pascalCase, ProgramNode } from '@kinobi-so/nodes';
+import { camelCase, InstructionNode, isNode, pascalCase, ProgramNode } from '@kinobi-so/nodes';
 
 import { ResolvedInstructionInput } from '../../../visitors';
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
@@ -51,7 +51,9 @@ export function getInstructionFunctionFragment(
         (instructionNode.extraArguments ?? []).filter(
             field => !field.defaultValue || field.defaultValueStrategy !== 'omitted',
         ).length > 0;
-    const hasAnyArgs = hasDataArgs || hasExtraArgs;
+    const hasRemainingAccountArgs =
+        (instructionNode.remainingAccounts ?? []).filter(({ value }) => isNode(value, 'argumentValueNode')).length > 0;
+    const hasAnyArgs = hasDataArgs || hasExtraArgs || hasRemainingAccountArgs;
     const instructionDataName = nameApi.instructionDataType(instructionNode.name);
     const programAddressConstant = nameApi.programAddressConstant(programNode.name);
     const encoderFunction = customData


### PR DESCRIPTION
Fix an error in the JS renderer that causes a `Cannot find name 'args'` error.

This is because when an instruction has no arguments, the `args` variable won't be generated. However, when an instruction has remaining accounts that rely on the `argumentValueNode`, then we need that variable to exist.

The fix is to update the value of the `hasAnyArgs` helper to also include `remainingAccountsNodes` of values `argumentValueNode`.