### PR TITLE
Fix unused args variable on sync instruction functions on JS renderer

### DIFF
--- a/.changeset/weak-coats-relate.md
+++ b/.changeset/weak-coats-relate.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/renderers-js": patch
+---
+
+Fix unused args variable on sync instruction functions

--- a/packages/renderers-js/src/fragments/instructionFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionFunction.ts
@@ -42,18 +42,6 @@ export function getInstructionFunctionFragment(
     const hasLegacyOptionalAccounts =
         instructionNode.optionalAccountStrategy === 'omitted' &&
         instructionNode.accounts.some(account => account.isOptional);
-    const hasData = !!customData || instructionNode.arguments.length > 0;
-    const hasDataArgs =
-        !!customData ||
-        instructionNode.arguments.filter(field => !field.defaultValue || field.defaultValueStrategy !== 'omitted')
-            .length > 0;
-    const hasExtraArgs =
-        (instructionNode.extraArguments ?? []).filter(
-            field => !field.defaultValue || field.defaultValueStrategy !== 'omitted',
-        ).length > 0;
-    const hasRemainingAccountArgs =
-        (instructionNode.remainingAccounts ?? []).filter(({ value }) => isNode(value, 'argumentValueNode')).length > 0;
-    const hasAnyArgs = hasDataArgs || hasExtraArgs || hasRemainingAccountArgs;
     const instructionDataName = nameApi.instructionDataType(instructionNode.name);
     const programAddressConstant = nameApi.programAddressConstant(programNode.name);
     const encoderFunction = customData
@@ -95,6 +83,19 @@ export function getInstructionFunctionFragment(
         }
         return useAsync ? `Promise<${returnType}>` : returnType;
     };
+
+    const hasData = !!customData || instructionNode.arguments.length > 0;
+    const hasDataArgs =
+        !!customData ||
+        instructionNode.arguments.filter(field => !field.defaultValue || field.defaultValueStrategy !== 'omitted')
+            .length > 0;
+    const hasExtraArgs =
+        (instructionNode.extraArguments ?? []).filter(
+            field => !field.defaultValue || field.defaultValueStrategy !== 'omitted',
+        ).length > 0 && hasResolver;
+    const hasRemainingAccountArgs =
+        (instructionNode.remainingAccounts ?? []).filter(({ value }) => isNode(value, 'argumentValueNode')).length > 0;
+    const hasAnyArgs = hasDataArgs || hasExtraArgs || hasRemainingAccountArgs;
 
     const functionFragment = fragmentFromTemplate('instructionFunction.njk', {
         argsTypeFragment,

--- a/packages/renderers-js/src/fragments/instructionFunction.ts
+++ b/packages/renderers-js/src/fragments/instructionFunction.ts
@@ -42,6 +42,23 @@ export function getInstructionFunctionFragment(
     const hasLegacyOptionalAccounts =
         instructionNode.optionalAccountStrategy === 'omitted' &&
         instructionNode.accounts.some(account => account.isOptional);
+    const instructionDependencies = getInstructionDependencies(instructionNode, asyncResolvers, useAsync);
+    const argDependencies = instructionDependencies.filter(isNodeFilter('argumentValueNode')).map(node => node.name);
+    console.log({ argDependencies });
+    const hasData = !!customData || instructionNode.arguments.length > 0;
+    const hasDataArgs =
+        !!customData ||
+        instructionNode.arguments.filter(field => !field.defaultValue || field.defaultValueStrategy !== 'omitted')
+            .length > 0;
+    const hasExtraArgs =
+        (instructionNode.extraArguments ?? []).filter(
+            field =>
+                (!field.defaultValue || field.defaultValueStrategy !== 'omitted') &&
+                argDependencies.includes(field.name),
+        ).length > 0;
+    const hasRemainingAccountArgs =
+        (instructionNode.remainingAccounts ?? []).filter(({ value }) => isNode(value, 'argumentValueNode')).length > 0;
+    const hasAnyArgs = hasDataArgs || hasExtraArgs || hasRemainingAccountArgs;
     const instructionDataName = nameApi.instructionDataType(instructionNode.name);
     const programAddressConstant = nameApi.programAddressConstant(programNode.name);
     const encoderFunction = customData
@@ -83,24 +100,6 @@ export function getInstructionFunctionFragment(
         }
         return useAsync ? `Promise<${returnType}>` : returnType;
     };
-
-    const instructionDependencies = getInstructionDependencies(instructionNode, asyncResolvers, useAsync);
-    const argDependencies = instructionDependencies.filter(isNodeFilter('argumentValueNode')).map(node => node.name);
-    console.log(argDependencies);
-    const hasData = !!customData || instructionNode.arguments.length > 0;
-    const hasDataArgs =
-        !!customData ||
-        instructionNode.arguments.filter(field => !field.defaultValue || field.defaultValueStrategy !== 'omitted')
-            .length > 0;
-    const hasExtraArgs =
-        (instructionNode.extraArguments ?? []).filter(
-            field =>
-                (!field.defaultValue || field.defaultValueStrategy !== 'omitted') &&
-                argDependencies.includes(field.name),
-        ).length > 0;
-    const hasRemainingAccountArgs =
-        (instructionNode.remainingAccounts ?? []).filter(({ value }) => isNode(value, 'argumentValueNode')).length > 0;
-    const hasAnyArgs = hasDataArgs || hasExtraArgs || hasRemainingAccountArgs;
 
     const functionFragment = fragmentFromTemplate('instructionFunction.njk', {
         argsTypeFragment,

--- a/packages/renderers-js/src/utils/async.ts
+++ b/packages/renderers-js/src/utils/async.ts
@@ -2,6 +2,7 @@ import {
     AccountValueNode,
     accountValueNode,
     ArgumentValueNode,
+    argumentValueNode,
     CamelCaseString,
     InstructionAccountNode,
     InstructionArgumentNode,
@@ -73,6 +74,10 @@ export function getInstructionDependencies(
 
     if (isNode(input.defaultValue, ['accountValueNode', 'accountBumpValueNode'])) {
         return [accountValueNode(input.defaultValue.name)];
+    }
+
+    if (isNode(input.defaultValue, ['argumentValueNode'])) {
+        return [argumentValueNode(input.defaultValue.name)];
     }
 
     if (isNode(input.defaultValue, 'pdaValueNode')) {

--- a/packages/renderers-js/test/instructionsPage.test.ts
+++ b/packages/renderers-js/test/instructionsPage.test.ts
@@ -1,0 +1,44 @@
+import {
+    instructionArgumentNode,
+    instructionNode,
+    numberTypeNode,
+    programNode,
+    resolverValueNode,
+} from '@kinobi-so/nodes';
+import { visit } from '@kinobi-so/visitors-core';
+import { test } from 'vitest';
+
+import { getRenderMapVisitor } from '../src';
+import { codeContains, codeDoesNotContain } from './_setup';
+
+test('it only renders the args variable on the async function if the sync function does not need it', async () => {
+    // Given the following instruction with an async resolver and an extra argument.
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                extraArguments: [
+                    instructionArgumentNode({
+                        defaultValue: resolverValueNode('myAsyncResolver'),
+                        name: 'foo',
+                        type: numberTypeNode('u64'),
+                    }),
+                ],
+                name: 'create',
+            }),
+        ],
+        name: 'myProgram',
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor({ asyncResolvers: ['myAsyncResolver'] }));
+
+    // And split the async and sync functions.
+    const [asyncFunction, syncFunction] = renderMap
+        .get('instructions/create.ts')
+        .split(/export\s+function\s+getCreateInstruction/);
+
+    // Then we expect only the async function to contain the args variable.
+    await codeContains(asyncFunction, ['// Original args.', 'const args = { ...input }']);
+    await codeDoesNotContain(syncFunction, ['// Original args.', 'const args = { ...input }']);
+});

--- a/packages/visitors-core/src/getResolvedInstructionInputsVisitor.ts
+++ b/packages/visitors-core/src/getResolvedInstructionInputsVisitor.ts
@@ -9,6 +9,7 @@ import {
     AccountValueNode,
     accountValueNode,
     ArgumentValueNode,
+    argumentValueNode,
     CamelCaseString,
     getAllInstructionArguments,
     InstructionAccountNode,
@@ -265,6 +266,10 @@ export function getInstructionDependencies(input: InstructionInput | Instruction
 
     if (isNode(input.defaultValue, ['accountValueNode', 'accountBumpValueNode'])) {
         return [accountValueNode(input.defaultValue.name)];
+    }
+
+    if (isNode(input.defaultValue, ['argumentValueNode'])) {
+        return [argumentValueNode(input.defaultValue.name)];
     }
 
     if (isNode(input.defaultValue, 'pdaValueNode')) {


### PR DESCRIPTION
Prior to this PR, a TypeScript/Lint "unused variable" warning was created on the synchronous function of generated instruction helpers if the all of the following conditions were true:
- Your instruction used `extraArguments` but no `arguments`.
- Your instruction used an async `resolver`.

This PR fixes this.