### PR TITLE
Add default impl for instruction data struct

### DIFF
--- a/.changeset/good-apricots-sell.md
+++ b/.changeset/good-apricots-sell.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/renderers-rust": patch
+---
+
+Add default impl for instruction data struct in Rust renderer

--- a/packages/renderers-rust/e2e/memo/src/generated/instructions/add_memo.rs
+++ b/packages/renderers-rust/e2e/memo/src/generated/instructions/add_memo.rs
@@ -48,6 +48,12 @@ impl AddMemoInstructionData {
     }
 }
 
+impl Default for AddMemoInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddMemoInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/advance_nonce_account.rs
@@ -63,6 +63,12 @@ impl AdvanceNonceAccountInstructionData {
     }
 }
 
+impl Default for AdvanceNonceAccountInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Instruction builder for `AdvanceNonceAccount`.
 ///
 /// ### Accounts:

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate.rs
@@ -55,6 +55,12 @@ impl AllocateInstructionData {
     }
 }
 
+impl Default for AllocateInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocateInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/allocate_with_seed.rs
@@ -62,6 +62,12 @@ impl AllocateWithSeedInstructionData {
     }
 }
 
+impl Default for AllocateWithSeedInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocateWithSeedInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign.rs
@@ -56,6 +56,12 @@ impl AssignInstructionData {
     }
 }
 
+impl Default for AssignInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AssignInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/assign_with_seed.rs
@@ -62,6 +62,12 @@ impl AssignWithSeedInstructionData {
     }
 }
 
+impl Default for AssignWithSeedInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AssignWithSeedInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/authorize_nonce_account.rs
@@ -64,6 +64,12 @@ impl AuthorizeNonceAccountInstructionData {
     }
 }
 
+impl Default for AuthorizeNonceAccountInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthorizeNonceAccountInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account.rs
@@ -61,6 +61,12 @@ impl CreateAccountInstructionData {
     }
 }
 
+impl Default for CreateAccountInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAccountInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/create_account_with_seed.rs
@@ -69,6 +69,12 @@ impl CreateAccountWithSeedInstructionData {
     }
 }
 
+impl Default for CreateAccountWithSeedInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAccountWithSeedInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/initialize_nonce_account.rs
@@ -70,6 +70,12 @@ impl InitializeNonceAccountInstructionData {
     }
 }
 
+impl Default for InitializeNonceAccountInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeNonceAccountInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol.rs
@@ -61,6 +61,12 @@ impl TransferSolInstructionData {
     }
 }
 
+impl Default for TransferSolInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferSolInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
@@ -70,6 +70,12 @@ impl TransferSolWithSeedInstructionData {
     }
 }
 
+impl Default for TransferSolWithSeedInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferSolWithSeedInstructionArgs {

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
@@ -51,6 +51,12 @@ impl UpgradeNonceAccountInstructionData {
     }
 }
 
+impl Default for UpgradeNonceAccountInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Instruction builder for `UpgradeNonceAccount`.
 ///
 /// ### Accounts:

--- a/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
@@ -81,6 +81,12 @@ impl WithdrawNonceAccountInstructionData {
     }
 }
 
+impl Default for WithdrawNonceAccountInstructionData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WithdrawNonceAccountInstructionArgs {

--- a/packages/renderers-rust/public/templates/instructionsPage.njk
+++ b/packages/renderers-rust/public/templates/instructionsPage.njk
@@ -128,6 +128,12 @@ impl {{ instruction.name | pascalCase }}InstructionData {
   }
 }
 
+impl Default for {{ instruction.name | pascalCase }}InstructionData {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 {% if hasArgs %}
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/packages/renderers-rust/test/instructionsPage.test.ts
+++ b/packages/renderers-rust/test/instructionsPage.test.ts
@@ -47,3 +47,18 @@ test('it renders an instruction with a remainder str', () => {
         `pub memo: RemainderStr`,
     ]);
 });
+
+test('it renders a default impl for instruction data struct', () => {
+    // Given the following program with 1 instruction.
+    const node = programNode({
+        instructions: [instructionNode({ name: 'mintTokens' })],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the following pub struct.
+    codeContains(renderMap.get('instructions/mint_tokens.rs'), [`impl Default for MintTokensInstructionData`, `fn default(`]);
+});

--- a/packages/renderers-rust/test/instructionsPage.test.ts
+++ b/packages/renderers-rust/test/instructionsPage.test.ts
@@ -60,5 +60,8 @@ test('it renders a default impl for instruction data struct', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following pub struct.
-    codeContains(renderMap.get('instructions/mint_tokens.rs'), [`impl Default for MintTokensInstructionData`, `fn default(`]);
+    codeContains(renderMap.get('instructions/mint_tokens.rs'), [
+        `impl Default for MintTokensInstructionData`,
+        `fn default(`,
+    ]);
 });

--- a/packages/renderers-rust/test/instructionsPage.test.ts
+++ b/packages/renderers-rust/test/instructionsPage.test.ts
@@ -59,7 +59,7 @@ test('it renders a default impl for instruction data struct', () => {
     // When we render it.
     const renderMap = visit(node, getRenderMapVisitor());
 
-    // Then we expect the following pub struct.
+    // Then we expect the following Default trait to be implemented.
     codeContains(renderMap.get('instructions/mint_tokens.rs'), [
         `impl Default for MintTokensInstructionData`,
         `fn default(`,


### PR DESCRIPTION
This PR adds a `Default` impl for instruction data structs.