### PR TITLE
Remove Anchor V01 Accounts from Defined Types

### DIFF
--- a/.changeset/hip-years-clean.md
+++ b/.changeset/hip-years-clean.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/nodes-from-anchor": patch
+---
+
+Remove Anchor V01 accounts from defined types to resolve duplicate exports in generated clients

--- a/packages/nodes-from-anchor/src/v01/ProgramNode.ts
+++ b/packages/nodes-from-anchor/src/v01/ProgramNode.ts
@@ -13,13 +13,13 @@ export function programNodeFromAnchorV01(idl: IdlV01): ProgramNode {
     const instructions = idl.instructions ?? [];
     const errors = idl.errors ?? [];
 
-    const definedTypes = types.map(definedTypeNodeFromAnchorV01);
+    const filteredTypes = types.filter(type => !accounts.some(account => account.name === type.name));
+    const definedTypes = filteredTypes.map(definedTypeNodeFromAnchorV01);
     const accountNodeFromAnchorV01 = accountNodeFromAnchorV01WithTypeDefinition(types);
     const pdas = instructions
         .flatMap<IdlV01InstructionAccount>(instruction => instruction.accounts)
         .filter(account => !!account.pda && !account.pda?.program)
         .map(pdaNodeFromAnchorV01);
-
     return programNode({
         accounts: accounts.map(accountNodeFromAnchorV01),
         definedTypes,

--- a/packages/nodes-from-anchor/test/v01/ProgramNode.test.ts
+++ b/packages/nodes-from-anchor/test/v01/ProgramNode.test.ts
@@ -2,7 +2,6 @@ import {
     accountNode,
     bytesTypeNode,
     constantPdaSeedNode,
-    definedTypeNode,
     errorNode,
     fieldDiscriminatorNode,
     instructionAccountNode,
@@ -65,7 +64,7 @@ test('it creates program nodes', () => {
                     name: 'myAccount',
                 }),
             ],
-            definedTypes: [definedTypeNode({ name: 'myAccount', type: structTypeNode([]) })],
+            definedTypes: [],
             errors: [
                 errorNode({
                     code: 42,


### PR DESCRIPTION
resolves https://github.com/kinobi-so/kinobi/issues/36

## Changes
- Remove types from the anchor idl that match up with accounts before generating definedTypes.