### PR TITLE
Add getOrThrow implementation

### DIFF
--- a/.changeset/afraid-experts-give.md
+++ b/.changeset/afraid-experts-give.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/visitors-core": patch
+---
+
+Add missing getOrThrow implementation

--- a/packages/visitors-core/src/LinkableDictionary.ts
+++ b/packages/visitors-core/src/LinkableDictionary.ts
@@ -49,7 +49,7 @@ export class LinkableDictionary {
     getOrThrow(linkNode: AccountLinkNode): AccountNode;
     getOrThrow(linkNode: DefinedTypeLinkNode): DefinedTypeNode;
     getOrThrow(linkNode: LinkNode): LinkableNode {
-        let node = this.get(linkNode);
+        const node = this.get(linkNode);
 
         if (node) {
             return node;

--- a/packages/visitors-core/src/LinkableDictionary.ts
+++ b/packages/visitors-core/src/LinkableDictionary.ts
@@ -49,24 +49,23 @@ export class LinkableDictionary {
     getOrThrow(linkNode: AccountLinkNode): AccountNode;
     getOrThrow(linkNode: DefinedTypeLinkNode): DefinedTypeNode;
     getOrThrow(linkNode: LinkNode): LinkableNode {
-        const node = this.get(linkNode);
+        const node = this.get(linkNode as ProgramLinkNode) as LinkableNode;
 
-        if (node) {
-            return node;
+        if (!node) {
+            throw new KinobiError(KINOBI_ERROR__LINKED_NODE_NOT_FOUND, {
+                kind: linkNode.kind,
+                linkNode,
+                name: linkNode.name,
+            });
         }
 
-        throw new KinobiError(KINOBI_ERROR__LINKED_NODE_NOT_FOUND, {
-            kind: linkNode.kind,
-            linkNode,
-            name: linkNode.name,
-        });
+        return node;
     }
 
     get(linkNode: ProgramLinkNode): ProgramNode | undefined;
     get(linkNode: PdaLinkNode): PdaNode | undefined;
     get(linkNode: AccountLinkNode): AccountNode | undefined;
     get(linkNode: DefinedTypeLinkNode): DefinedTypeNode | undefined;
-    get(linkNode: LinkNode): LinkableNode | undefined;
     get(linkNode: LinkNode): LinkableNode | undefined {
         if (linkNode.importFrom) {
             return undefined;

--- a/packages/visitors-core/src/LinkableDictionary.ts
+++ b/packages/visitors-core/src/LinkableDictionary.ts
@@ -49,6 +49,12 @@ export class LinkableDictionary {
     getOrThrow(linkNode: AccountLinkNode): AccountNode;
     getOrThrow(linkNode: DefinedTypeLinkNode): DefinedTypeNode;
     getOrThrow(linkNode: LinkNode): LinkableNode {
+        let node = this.get(linkNode);
+
+        if (node) {
+            return node;
+        }
+
         throw new KinobiError(KINOBI_ERROR__LINKED_NODE_NOT_FOUND, {
             kind: linkNode.kind,
             linkNode,
@@ -60,6 +66,7 @@ export class LinkableDictionary {
     get(linkNode: PdaLinkNode): PdaNode | undefined;
     get(linkNode: AccountLinkNode): AccountNode | undefined;
     get(linkNode: DefinedTypeLinkNode): DefinedTypeNode | undefined;
+    get(linkNode: LinkNode): LinkableNode | undefined;
     get(linkNode: LinkNode): LinkableNode | undefined {
         if (linkNode.importFrom) {
             return undefined;


### PR DESCRIPTION
This PR adds the implementation for `getOrThrow`, which seems to be missing. Without this, using defined types as arguments for instructions fails.