### PR TITLE
Allow PdaValueNode to inline their own PdaNode definition

### DIFF
--- a/.changeset/tasty-rocks-sleep.md
+++ b/.changeset/tasty-rocks-sleep.md
@@ -1,0 +1,9 @@
+---
+"@kinobi-so/renderers-js-umi": patch
+"@kinobi-so/renderers-js": patch
+"@kinobi-so/node-types": patch
+"@kinobi-so/visitors": patch
+"@kinobi-so/nodes": patch
+---
+
+Allow PdaValueNode to inline their own PdaNode definition

--- a/packages/node-types/src/PdaNode.ts
+++ b/packages/node-types/src/PdaNode.ts
@@ -7,6 +7,7 @@ export interface PdaNode<TSeeds extends PdaSeedNode[] = PdaSeedNode[]> {
     // Data.
     readonly name: CamelCaseString;
     readonly docs: Docs;
+    readonly programId?: string;
 
     // Children.
     readonly seeds: TSeeds;

--- a/packages/node-types/src/contextualValueNodes/PdaValueNode.ts
+++ b/packages/node-types/src/contextualValueNodes/PdaValueNode.ts
@@ -1,10 +1,11 @@
 import type { PdaLinkNode } from '../linkNodes';
+import type { PdaNode } from '../PdaNode';
 import type { PdaSeedValueNode } from './PdaSeedValueNode';
 
 export interface PdaValueNode<TSeeds extends PdaSeedValueNode[] = PdaSeedValueNode[]> {
     readonly kind: 'pdaValueNode';
 
     // Children.
-    readonly pda: PdaLinkNode;
+    readonly pda: PdaLinkNode | PdaNode;
     readonly seeds: TSeeds;
 }

--- a/packages/nodes/src/PdaNode.ts
+++ b/packages/nodes/src/PdaNode.ts
@@ -17,6 +17,7 @@ export function pdaNode<const TSeeds extends PdaSeedNode[]>(input: PdaNodeInput<
         // Data.
         name: camelCase(input.name),
         docs: parseDocs(input.docs),
+        ...(input.programId && { programId: input.programId }),
 
         // Children.
         seeds: input.seeds,

--- a/packages/nodes/src/contextualValueNodes/PdaValueNode.ts
+++ b/packages/nodes/src/contextualValueNodes/PdaValueNode.ts
@@ -1,9 +1,9 @@
-import type { PdaLinkNode, PdaSeedValueNode, PdaValueNode } from '@kinobi-so/node-types';
+import type { PdaLinkNode, PdaNode, PdaSeedValueNode, PdaValueNode } from '@kinobi-so/node-types';
 
 import { pdaLinkNode } from '../linkNodes';
 
 export function pdaValueNode<const TSeeds extends PdaSeedValueNode[] = []>(
-    pda: PdaLinkNode | string,
+    pda: PdaLinkNode | PdaNode | string,
     seeds: TSeeds = [] as PdaSeedValueNode[] as TSeeds,
 ): PdaValueNode<TSeeds> {
     return Object.freeze({

--- a/packages/renderers-js-umi/test/instructionsPage.test.ts
+++ b/packages/renderers-js-umi/test/instructionsPage.test.ts
@@ -1,112 +1,20 @@
 import {
     accountValueNode,
-    argumentValueNode,
     constantPdaSeedNodeFromString,
     instructionAccountNode,
-    instructionArgumentNode,
     instructionNode,
-    numberTypeNode,
     pdaNode,
     pdaSeedValueNode,
     pdaValueNode,
     programNode,
     publicKeyTypeNode,
-    resolverValueNode,
     variablePdaSeedNode,
 } from '@kinobi-so/nodes';
 import { visit } from '@kinobi-so/visitors-core';
 import { test } from 'vitest';
 
 import { getRenderMapVisitor } from '../src';
-import { codeContains, codeDoesNotContain, renderMapContains, renderMapContainsImports } from './_setup';
-
-test('it renders instruction accounts that can either be signer or non-signer', async () => {
-    // Given the following instruction with a signer or non-signer account.
-    const node = programNode({
-        instructions: [
-            instructionNode({
-                accounts: [instructionAccountNode({ isSigner: 'either', isWritable: false, name: 'myAccount' })],
-                name: 'myInstruction',
-            }),
-        ],
-        name: 'myProgram',
-        publicKey: '1111',
-    });
-
-    // When we render it.
-    const renderMap = visit(node, getRenderMapVisitor());
-
-    // Then we expect the input to be rendered as either a signer or non-signer.
-    await renderMapContains(renderMap, 'instructions/myInstruction.ts', [
-        'myAccount: Address<TAccountMyAccount> | TransactionSigner<TAccountMyAccount>;',
-    ]);
-});
-
-test('it renders extra arguments that default on each other', async () => {
-    // Given the following instruction with two extra arguments
-    // such that one defaults to the other.
-    const node = programNode({
-        instructions: [
-            instructionNode({
-                extraArguments: [
-                    instructionArgumentNode({
-                        defaultValue: argumentValueNode('bar'),
-                        name: 'foo',
-                        type: numberTypeNode('u64'),
-                    }),
-                    instructionArgumentNode({
-                        name: 'bar',
-                        type: numberTypeNode('u64'),
-                    }),
-                ],
-                name: 'create',
-            }),
-        ],
-        name: 'myProgram',
-        publicKey: '1111',
-    });
-
-    // When we render it.
-    const renderMap = visit(node, getRenderMapVisitor());
-
-    // Then we expect the following code to be rendered.
-    await renderMapContains(renderMap, 'instructions/create.ts', [
-        'const args = { ...input }',
-        'if (!args.foo) { args.foo = expectSome(args.bar); }',
-    ]);
-});
-
-test('it only renders the args variable on the async function if the sync function does not need it', async () => {
-    // Given the following instruction with an async resolver and an extra argument.
-    const node = programNode({
-        instructions: [
-            instructionNode({
-                extraArguments: [
-                    instructionArgumentNode({
-                        defaultValue: resolverValueNode('myAsyncResolver'),
-                        name: 'foo',
-                        type: numberTypeNode('u64'),
-                    }),
-                ],
-                name: 'create',
-            }),
-        ],
-        name: 'myProgram',
-        publicKey: '1111',
-    });
-
-    // When we render it.
-    const renderMap = visit(node, getRenderMapVisitor({ asyncResolvers: ['myAsyncResolver'] }));
-
-    // And split the async and sync functions.
-    const [asyncFunction, syncFunction] = renderMap
-        .get('instructions/create.ts')
-        .split(/export\s+function\s+getCreateInstruction/);
-
-    // Then we expect only the async function to contain the args variable.
-    await codeContains(asyncFunction, ['// Original args.', 'const args = { ...input }']);
-    await codeDoesNotContain(syncFunction, ['// Original args.', 'const args = { ...input }']);
-});
+import { renderMapContains, renderMapContainsImports } from './_setup';
 
 test('it renders instruction accounts with linked PDAs as default value', async () => {
     // Given the following program with a PDA node and an instruction account using it as default value.
@@ -145,11 +53,11 @@ test('it renders instruction accounts with linked PDAs as default value', async 
 
     // Then we expect the following default value to be rendered.
     await renderMapContains(renderMap, 'instructions/increment.ts', [
-        'if (!accounts.counter.value) { ' +
-            'accounts.counter.value = await findCounterPda( { authority: expectAddress ( accounts.authority.value ) } ); ' +
+        'if (!resolvedAccounts.counter.value) { ' +
+            'resolvedAccounts.counter.value = findCounterPda( context, { authority: expectPublicKey ( resolvedAccounts.authority.value ) } ); ' +
             '}',
     ]);
-    renderMapContainsImports(renderMap, 'instructions/increment.ts', { '../pdas': ['findCounterPda'] });
+    renderMapContainsImports(renderMap, 'instructions/increment.ts', { '../accounts': ['findCounterPda'] });
 });
 
 test('it renders instruction accounts with inlined PDAs as default value', async () => {
@@ -187,19 +95,13 @@ test('it renders instruction accounts with inlined PDAs as default value', async
 
     // Then we expect the following default value to be rendered.
     await renderMapContains(renderMap, 'instructions/increment.ts', [
-        'if (!accounts.counter.value) { ' +
-            'accounts.counter.value = await getProgramDerivedAddress( { ' +
-            '  programAddress, ' +
-            '  seeds: [ ' +
-            "    getUtf8Encoder().encode('counter'), " +
-            '    getAddressEncoder().encode(expectAddress(accounts.authority.value)) ' +
-            '  ] ' +
-            '} ); ' +
+        'if (!resolvedAccounts.counter.value) { ' +
+            'resolvedAccounts.counter.value = context.eddsa.findPda( programId, [ ' +
+            "  string({ size: 'variable' }).serialize( 'counter' ), " +
+            '  publicKeySerializer().serialize( expectPublicKey( resolvedAccounts.authority.value ) ) ' +
+            '] ); ' +
             '}',
     ]);
-    renderMapContainsImports(renderMap, 'instructions/increment.ts', {
-        '@solana/web3.js': ['getProgramDerivedAddress'],
-    });
 });
 
 test('it renders instruction accounts with inlined PDAs from another program as default value', async () => {
@@ -238,17 +140,14 @@ test('it renders instruction accounts with inlined PDAs from another program as 
 
     // Then we expect the following default value to be rendered.
     await renderMapContains(renderMap, 'instructions/increment.ts', [
-        'if (!accounts.counter.value) { ' +
-            'accounts.counter.value = await getProgramDerivedAddress( { ' +
-            "  programAddress: '2222' as Address<'2222'>, " +
-            '  seeds: [ ' +
-            "    getUtf8Encoder().encode('counter'), " +
-            '    getAddressEncoder().encode(expectAddress(accounts.authority.value)) ' +
+        'if (!resolvedAccounts.counter.value) { ' +
+            'resolvedAccounts.counter.value = context.eddsa.findPda( ' +
+            "  context.programs.getPublicKey('2222', '2222'), " +
+            '  [ ' +
+            "    string({ size: 'variable' }).serialize( 'counter' ), " +
+            '    publicKeySerializer().serialize( expectPublicKey( resolvedAccounts.authority.value ) ) ' +
             '  ] ' +
-            '} ); ' +
+            '); ' +
             '}',
     ]);
-    renderMapContainsImports(renderMap, 'instructions/increment.ts', {
-        '@solana/web3.js': ['Address', 'getProgramDerivedAddress'],
-    });
 });

--- a/packages/visitors/src/fillDefaultPdaSeedValuesVisitor.ts
+++ b/packages/visitors/src/fillDefaultPdaSeedValuesVisitor.ts
@@ -38,7 +38,7 @@ export function fillDefaultPdaSeedValuesVisitor(
             visitPdaValue(node, { next }) {
                 const visitedNode = next(node);
                 assertIsNode(visitedNode, 'pdaValueNode');
-                const foundPda = linkables.get(visitedNode.pda);
+                const foundPda = isNode(visitedNode.pda, 'pdaNode') ? visitedNode.pda : linkables.get(visitedNode.pda);
                 if (!foundPda) return visitedNode;
                 const seeds = addDefaultSeedValuesFromPdaWhenMissing(instruction, foundPda, visitedNode.seeds);
                 if (strictMode && !allSeedsAreValid(instruction, foundPda, seeds)) {


### PR DESCRIPTION
As discussed in PR #42, this PR allows `PdaValueNodes` to define their own `PdaNode` instead of requiring a top-level `PdaNode` to exist on the program.

Renderers have been updated such that, when coming across a `PdaValueNode` with an inlined `PdaNode`, it won't try to import a generated PDA function but instead, will derive the PDA in situ.

Both JavaScript renderers have been updated. The Rust renderer currently doesn't use this information which is why this PR doesn't contain any changes in the Rust renderer.