### PR TITLE
Add copy derive to scalar enums

### DIFF
--- a/.changeset/tall-beds-share.md
+++ b/.changeset/tall-beds-share.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/renderers-rust": patch
+---
+
+Add copy derive to scalar enums in Rust renderer

--- a/packages/renderers-rust/e2e/system/src/generated/types/nonce_state.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/types/nonce_state.rs
@@ -10,7 +10,16 @@ use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
 #[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+    BorshSerialize,
+    BorshDeserialize,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Copy,
+    PartialOrd,
+    Hash,
+    FromPrimitive,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NonceState {

--- a/packages/renderers-rust/e2e/system/src/generated/types/nonce_version.rs
+++ b/packages/renderers-rust/e2e/system/src/generated/types/nonce_version.rs
@@ -10,7 +10,16 @@ use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
 #[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+    BorshSerialize,
+    BorshDeserialize,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Copy,
+    PartialOrd,
+    Hash,
+    FromPrimitive,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NonceVersion {

--- a/packages/renderers-rust/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-rust/src/getTypeManifestVisitor.ts
@@ -132,7 +132,7 @@ export function getTypeManifestVisitor(options: { nestedStruct?: boolean; parent
                     manifest.imports.add(['borsh::BorshSerialize', 'borsh::BorshDeserialize']);
                     const traits = ['BorshSerialize', 'BorshDeserialize', 'Clone', 'Debug', 'Eq', 'PartialEq'];
                     if (isNode(definedType.type, 'enumTypeNode') && isScalarEnum(definedType.type)) {
-                        traits.push('PartialOrd', 'Hash', 'FromPrimitive');
+                        traits.push('Copy', 'PartialOrd', 'Hash', 'FromPrimitive');
                         manifest.imports.add(['num_derive::FromPrimitive']);
                     }
                     return {

--- a/packages/renderers-rust/test/_setup.ts
+++ b/packages/renderers-rust/test/_setup.ts
@@ -10,3 +10,14 @@ export function codeContains(actual: string, expected: (RegExp | string)[] | Reg
         }
     });
 }
+
+export function codeNotContains(actual: string, expected: (RegExp | string)[] | RegExp | string) {
+    const expectedArray = Array.isArray(expected) ? expected : [expected];
+    expectedArray.forEach(e => {
+        if (typeof e === 'string') {
+            expect(actual).not.toContain(e);
+        } else {
+            expect(actual).not.toMatch(e);
+        }
+    });
+}


### PR DESCRIPTION
This PR adds a `Copy` derive to scalar enums when rendering Rust clients.