### PR TITLE
Update programErrors.njk

### DIFF
--- a/packages/renderers-js/public/templates/fragments/programErrors.njk
+++ b/packages/renderers-js/public/templates/fragments/programErrors.njk
@@ -11,7 +11,7 @@ export type {{ programErrorUnion }} =
   {% endfor %};
 
 let {{ programErrorMessagesMap }}: Record<{{ programErrorUnion }}, string> | undefined;
-if (__DEV__) {
+if ("__DEV__" in global && __DEV__) {
   {{ programErrorMessagesMap }} = {
     {% for error in errors | sort(false, false, 'name') %}
       [{{ getProgramErrorConstant(error.name) }}]: `{{ error.message }}`,
@@ -20,7 +20,7 @@ if (__DEV__) {
 }
 
 export function {{ programGetErrorMessageFunction }}(code: {{ programErrorUnion }}): string {
-  if (__DEV__) {
+  if ("__DEV__" in global && __DEV__) {
     return ({{ programErrorMessagesMap }} as Record<{{ programErrorUnion }}, string>)[code];
   }
 


### PR DESCRIPTION
In certain conditions, `__DEV__` is not defined on the global object (for example when not using a bundler). This can cause a fatal error to occur unless `__DEV__` is defined. This for example happens when trying to import the error file from mocha or jest (without the right env)

```
ReferenceError: __DEV__ is not defined
```

This PR merely fixes this fatal error that can be experienced downstream but does not offer any improvements/alternatives. In the future might be worth to make this more inclusive but there does not seem to really be a standard:
* `process.env.NODE_ENV` in nodejs
* `__DEV__` for certain bundlers
* `process.env.VERCEL_ENV` in vercel
* etc.