### PR TITLE
fix: render PDA helper with programAddress = node.programId if defined 

### DIFF
--- a/.changeset/polite-cats-wash.md
+++ b/.changeset/polite-cats-wash.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-js': patch
+---
+
+Fix rendering PDA helper functions with a default programId.

--- a/packages/renderers-js/public/templates/fragments/pdaFunction.njk
+++ b/packages/renderers-js/public/templates/fragments/pdaFunction.njk
@@ -17,7 +17,7 @@ export async function {{ findPdaFunction }}(
   {% endif %}
   config: { programAddress?: Address | undefined } = {},
 ): Promise<ProgramDerivedAddress> {
-  const { programAddress = '{{ program.publicKey }}' as Address<'{{ program.publicKey }}'> } = config;
+  const { programAddress = '{{ programAddress }}' as Address<'{{ programAddress }}'> } = config;
   return await getProgramDerivedAddress({ programAddress, seeds: [
     {% for seed in seeds %}
       {% if seed.kind === 'constantPdaSeedNode' and seed.value.kind === 'programIdValueNode' %}

--- a/packages/renderers-js/src/fragments/pdaFunction.ts
+++ b/packages/renderers-js/src/fragments/pdaFunction.ts
@@ -37,7 +37,7 @@ export function getPdaFunctionFragment(
         findPdaFunction: nameApi.pdaFindFunction(pdaNode.name),
         hasVariableSeeds,
         pdaSeedsType: nameApi.pdaSeedsType(pdaNode.name),
-        program: programNode,
+        programAddress: pdaNode.programId ?? programNode.publicKey,
         seeds,
     })
         .mergeImportsWith(imports)

--- a/packages/renderers-js/test/pdasPage.test.ts
+++ b/packages/renderers-js/test/pdasPage.test.ts
@@ -41,6 +41,30 @@ test('it renders a PDA helper function and its input type', async () => {
     ]);
 });
 
+test('it renders a PDA helper function with a default program address', async () => {
+    // Given the following PDA node with a default program address.
+    const node = programNode({
+        name: 'myProgram',
+        pdas: [
+            pdaNode({
+                name: 'foo',
+                programId: 'myProgramId',
+                seeds: [constantPdaSeedNodeFromString('utf8', 'myPrefix')],
+            }),
+        ],
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the following PDA function using the programId as the default program address.
+    await renderMapContains(renderMap, 'pdas/foo.ts', [
+        'export async function findFooPda',
+        "const { programAddress = 'myProgramId' as Address<'myProgramId'> } = config;",
+    ]);
+});
+
 test('it renders an empty array of seeds for seedless PDAs', async () => {
     // Given the following program with 1 account and 1 pda with empty seeds.
     const node = programNode({


### PR DESCRIPTION
PDA helpers should generate PDA's with a default programAddress set to the provided PDA nodes' programId if programId is defined. If not defined, the default programAddress should be the encapsulating program node programId.

With this PR, the following test passes. All tests are passing locally. A changeset has been included.

```ts
test('it renders a PDA helper function with a default program address', async () => {
    // Given the following PDA node with a default program address.
    const node = programNode({
        name: 'myProgram',
        pdas: [
            pdaNode({
                name: 'foo',
                programId: 'myProgramId',
                seeds: [constantPdaSeedNodeFromString('utf8', 'myPrefix')],
            }),
        ],
        publicKey: '1111',
    });

    // When we render it.
    const renderMap = visit(node, getRenderMapVisitor());

    // Then we expect the following PDA function using the programId as the default program address.
    await renderMapContains(renderMap, 'pdas/foo.ts', [
        'export async function findFooPda',
        "const { programAddress = 'myProgramId' as Address<'myProgramId'> } = config;",
    ]);
});
```