### PR TITLE
Filter out type variant on imports

### DIFF
--- a/.changeset/shy-points-march.md
+++ b/.changeset/shy-points-march.md
@@ -2,4 +2,4 @@
 '@kinobi-so/renderers-js': patch
 ---
 
-Add missing type prefix for enums
+Filter out type variant on imports

--- a/.changeset/shy-points-march.md
+++ b/.changeset/shy-points-march.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-js': patch
+---
+
+Add missing type prefix for enums

--- a/packages/renderers-js/src/ImportMap.ts
+++ b/packages/renderers-js/src/ImportMap.ts
@@ -135,7 +135,18 @@ export class ImportMap {
                 return a.localeCompare(b);
             })
             .map(([module, imports]) => {
-                const joinedImports = [...imports].sort().join(', ');
+                const joinedImports = [...imports]
+                    .sort()
+                    .filter(i => {
+                        // import of a type can either be '<Type>' or 'type <Type>', so
+                        // we filter out 'type <Type>' variation if there is a '<Type>'
+                        const name = i.split(' ');
+                        if (name.length > 1) {
+                            return !imports.has(name[1]);
+                        }
+                        return true;
+                    })
+                    .join(', ');
                 return `import { ${joinedImports} } from '${module}';`;
             })
             .join('\n');

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -350,7 +350,9 @@ export function getTypeManifestVisitor(input: {
 
                     if (!node.value && isScalar) {
                         const variantName = nameApi.enumVariant(node.variant);
-                        manifest.value.setRender(`${enumName}.${variantName}`).addImports(importFrom, enumName);
+                        manifest.value
+                            .setRender(`${enumName}.${variantName}`)
+                            .addImports(importFrom, `type ${enumName}`);
                         return manifest;
                     }
 

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -350,9 +350,7 @@ export function getTypeManifestVisitor(input: {
 
                     if (!node.value && isScalar) {
                         const variantName = nameApi.enumVariant(node.variant);
-                        manifest.value
-                            .setRender(`${enumName}.${variantName}`)
-                            .addImports(importFrom, `type ${enumName}`);
+                        manifest.value.setRender(`${enumName}.${variantName}`).addImports(importFrom, enumName);
                         return manifest;
                     }
 

--- a/packages/renderers-js/test/accountsPage.test.ts
+++ b/packages/renderers-js/test/accountsPage.test.ts
@@ -78,5 +78,5 @@ test('it renders an account with a defined type link as discriminator', async ()
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following import list with a reference to the disciminator type.
-    await renderMapContains(renderMap, 'accounts/asset.ts', ['import { getKeyDecoder, getKeyEncoder, type Key }']);
+    await renderMapContains(renderMap, 'accounts/asset.ts', ['import { Key, getKeyDecoder, getKeyEncoder }']);
 });

--- a/packages/renderers-js/test/accountsPage.test.ts
+++ b/packages/renderers-js/test/accountsPage.test.ts
@@ -45,13 +45,12 @@ test('it renders an account with a defined type link as discriminator', async ()
     const node = programNode({
         accounts: [
             accountNode({
-                name: 'asset',
                 data: structTypeNode([
                     structFieldTypeNode({
-                        name: 'key',
-                        type: definedTypeLinkNode('Key'),
                         defaultValue: enumValueNode('key', 'Asset'),
                         defaultValueStrategy: 'omitted',
+                        name: 'key',
+                        type: definedTypeLinkNode('Key'),
                     }),
                     structFieldTypeNode({
                         name: 'mutable',
@@ -63,6 +62,7 @@ test('it renders an account with a defined type link as discriminator', async ()
                     }),
                 ]),
                 discriminators: [fieldDiscriminatorNode('key', 0)],
+                name: 'asset',
             }),
         ],
         definedTypes: [

--- a/packages/renderers-js/test/accountsPage.test.ts
+++ b/packages/renderers-js/test/accountsPage.test.ts
@@ -1,4 +1,19 @@
-import { accountNode, pdaLinkNode, pdaNode, programNode } from '@kinobi-so/nodes';
+import {
+    accountNode,
+    booleanTypeNode,
+    definedTypeLinkNode,
+    definedTypeNode,
+    enumEmptyVariantTypeNode,
+    enumTypeNode,
+    enumValueNode,
+    fieldDiscriminatorNode,
+    pdaLinkNode,
+    pdaNode,
+    programNode,
+    publicKeyTypeNode,
+    structFieldTypeNode,
+    structTypeNode,
+} from '@kinobi-so/nodes';
 import { visit } from '@kinobi-so/visitors-core';
 import { test } from 'vitest';
 
@@ -23,4 +38,45 @@ test('it renders PDA helpers for PDA with no seeds', async () => {
         'export async function fetchMaybeFooFromSeeds',
         'await findBarPda({ programAddress })',
     ]);
+});
+
+test('it renders an account with a defined type link as discriminator', async () => {
+    // Given the following program with 1 account with a discriminator.
+    const node = programNode({
+        accounts: [
+            accountNode({
+                name: 'asset',
+                data: structTypeNode([
+                    structFieldTypeNode({
+                        name: 'key',
+                        type: definedTypeLinkNode('Key'),
+                        defaultValue: enumValueNode('key', 'Asset'),
+                        defaultValueStrategy: 'omitted',
+                    }),
+                    structFieldTypeNode({
+                        name: 'mutable',
+                        type: booleanTypeNode(),
+                    }),
+                    structFieldTypeNode({
+                        name: 'owner',
+                        type: publicKeyTypeNode(),
+                    }),
+                ]),
+                discriminators: [fieldDiscriminatorNode('key', 0)],
+            }),
+        ],
+        definedTypes: [
+            definedTypeNode({
+                name: 'key',
+                type: enumTypeNode([enumEmptyVariantTypeNode('Uninitialized'), enumEmptyVariantTypeNode('Asset')]),
+            }),
+        ],
+        name: 'splToken',
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the following import list with a reference to the disciminator type.
+    await renderMapContains(renderMap, 'accounts/asset.ts', ['import { getKeyDecoder, getKeyEncoder, type Key }']);
 });


### PR DESCRIPTION
This PR modifies the `ImportMap` to filter out `type Type` variants from imports when the import for `Type` is present.

Instead of rendering with a duplicated import of `Key`:
```typescript
import { Key, getKeyDecoder, getKeyEncoder, type Key } from '../types';
```
The renderer will output:
```typescript
import { Key, getKeyDecoder, getKeyEncoder } from '../types';
```