### PR TITLE
Rust Renderer: Add toolchain arg to formatter

### DIFF
--- a/.changeset/little-planes-poke.md
+++ b/.changeset/little-planes-poke.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-rust': patch
+---
+
+Rust Renderer: Add toolchain arg to formatter

--- a/packages/renderers-rust/src/renderVisitor.ts
+++ b/packages/renderers-rust/src/renderVisitor.ts
@@ -9,6 +9,7 @@ export type RenderOptions = GetRenderMapOptions & {
     crateFolder?: string;
     deleteFolderBeforeRendering?: boolean;
     formatCode?: boolean;
+    toolchain?: 'nightly' | 'stable';
 };
 
 export function renderVisitor(path: string, options: RenderOptions = {}) {
@@ -24,7 +25,8 @@ export function renderVisitor(path: string, options: RenderOptions = {}) {
         // format the code
         if (options.formatCode) {
             if (options.crateFolder) {
-                runFormatter('cargo-fmt', ['--manifest-path', `${options.crateFolder}/Cargo.toml`]);
+                const toolchain = options.toolchain ? `+${options.toolchain}` : '+stable';
+                runFormatter('cargo', [toolchain, 'fmt', '--manifest-path', `${options.crateFolder}/Cargo.toml`]);
             } else {
                 logWarn('No crate folder specified, skipping formatting.');
             }

--- a/packages/renderers-rust/src/renderVisitor.ts
+++ b/packages/renderers-rust/src/renderVisitor.ts
@@ -9,7 +9,7 @@ export type RenderOptions = GetRenderMapOptions & {
     crateFolder?: string;
     deleteFolderBeforeRendering?: boolean;
     formatCode?: boolean;
-    toolchain?: 'nightly' | 'stable';
+    toolchain?: string;
 };
 
 export function renderVisitor(path: string, options: RenderOptions = {}) {
@@ -25,7 +25,7 @@ export function renderVisitor(path: string, options: RenderOptions = {}) {
         // format the code
         if (options.formatCode) {
             if (options.crateFolder) {
-                const toolchain = options.toolchain ? `+${options.toolchain}` : '+stable';
+                const toolchain = options.toolchain ?? '+stable';
                 runFormatter('cargo', [toolchain, 'fmt', '--manifest-path', `${options.crateFolder}/Cargo.toml`]);
             } else {
                 logWarn('No crate folder specified, skipping formatting.');


### PR DESCRIPTION
#### Problem

Projects using Kinobi may configure their `rustfmt.toml` to use nightly-only
formatting configurations.

Currently, Kinobi always uses the stable toolchain when running `cargo fmt`
upon generating Rust client code.

#### Summary of Changes

Add an option to `RenderOptions` for Rust toolchain, allowing users to configure
a Rust toolchain for formatting.