### PR TITLE
Fix Arg Lookup for Anchor V01 Seed Default Value Generation

### DIFF
--- a/.changeset/small-jars-play.md
+++ b/.changeset/small-jars-play.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/nodes-from-anchor": patch
+---
+
+Fix argument node lookup for anchor v01 instruction pda seeds.

--- a/packages/nodes-from-anchor/src/v01/InstructionAccountNode.ts
+++ b/packages/nodes-from-anchor/src/v01/InstructionAccountNode.ts
@@ -105,7 +105,8 @@ export function instructionAccountNodeFromAnchorV01(
                             }
                         }
                         case 'arg': {
-                            const argumentNode = instructionArguments.find(({ name }) => name === seed.path);
+                            const argumentName = camelCase(seed.path);
+                            const argumentNode = instructionArguments.find(({ name }) => name === argumentName);
                             if (!argumentNode) {
                                 throw new KinobiError(KINOBI_ERROR__ANCHOR__ARGUMENT_TYPE_MISSING, { name: seed.path });
                             }

--- a/packages/nodes-from-anchor/test/v01/ProgramNode.test.ts
+++ b/packages/nodes-from-anchor/test/v01/ProgramNode.test.ts
@@ -1,6 +1,7 @@
 import {
     accountNode,
     accountValueNode,
+    argumentValueNode,
     bytesTypeNode,
     constantPdaSeedNodeFromBytes,
     errorNode,
@@ -9,6 +10,7 @@ import {
     instructionAccountNode,
     instructionArgumentNode,
     instructionNode,
+    numberTypeNode,
     pdaNode,
     pdaSeedValueNode,
     pdaValueNode,
@@ -36,6 +38,7 @@ test('it creates program nodes', () => {
                             seeds: [
                                 { kind: 'const', value: [42, 31, 29] },
                                 { kind: 'account', path: 'owner' },
+                                { kind: 'arg', path: 'amount' },
                             ],
                         },
                     },
@@ -46,12 +49,17 @@ test('it creates program nodes', () => {
                         name: 'some_account',
                     },
                 ],
-                args: [],
+                args: [
+                    {
+                        name: 'amount',
+                        type: 'u8',
+                    },
+                ],
                 discriminator: [246, 28, 6, 87, 251, 45, 50, 42],
-                name: 'myInstruction',
+                name: 'my_instruction',
             },
         ],
-        metadata: { name: 'myProgram', spec: '0.1.0', version: '1.2.3' },
+        metadata: { name: 'my_program', spec: '0.1.0', version: '1.2.3' },
         types: [{ name: 'MyAccount', type: { fields: [{ name: 'delegate', type: 'pubkey' }], kind: 'struct' } }],
     });
 
@@ -94,9 +102,13 @@ test('it creates program nodes', () => {
                                     seeds: [
                                         constantPdaSeedNodeFromBytes('base16', '2a1f1d'),
                                         variablePdaSeedNode('owner', publicKeyTypeNode()),
+                                        variablePdaSeedNode('amount', numberTypeNode('u8')),
                                     ],
                                 }),
-                                [pdaSeedValueNode('owner', accountValueNode('owner'))],
+                                [
+                                    pdaSeedValueNode('owner', accountValueNode('owner')),
+                                    pdaSeedValueNode('amount', argumentValueNode('amount')),
+                                ],
                             ),
                             isSigner: false,
                             isWritable: false,
@@ -120,6 +132,7 @@ test('it creates program nodes', () => {
                             name: 'discriminator',
                             type: fixedSizeTypeNode(bytesTypeNode(), 8),
                         }),
+                        instructionArgumentNode({ name: 'amount', type: numberTypeNode('u8') }),
                     ],
                     discriminators: [fieldDiscriminatorNode('discriminator')],
                     name: 'myInstruction',


### PR DESCRIPTION
## Changes
- Convert name to camel case before searching argument node list as kinobi tracks all names in camel case format.