### PR TITLE
Add isProgramError helper in JS renderer

### DIFF
--- a/.changeset/tasty-lamps-marry.md
+++ b/.changeset/tasty-lamps-marry.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/renderers-js": patch
+---
+
+Add isProgramError helper

--- a/packages/renderers-js/e2e/anchor/src/generated/errors/wenTransferGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/errors/wenTransferGuard.ts
@@ -77,9 +77,8 @@ export function isWenTransferGuardError<
     instructions: Record<number, { programAddress: Address }>;
   },
   code?: TProgramErrorCode
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
-  context: { code: TProgramErrorCode };
-} {
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
+  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
   return isProgramError<TProgramErrorCode>(
     error,
     transactionMessage,

--- a/packages/renderers-js/e2e/anchor/src/generated/errors/wenTransferGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/errors/wenTransferGuard.ts
@@ -6,6 +6,14 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
+import {
+  isProgramError,
+  type Address,
+  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+  type SolanaError,
+} from '@solana/web3.js';
+import { WEN_TRANSFER_GUARD_PROGRAM_ADDRESS } from '../programs';
+
 /** CpiRuleEnforcementFailed: Cpi Rule Enforcement Failed */
 export const WEN_TRANSFER_GUARD_ERROR__CPI_RULE_ENFORCEMENT_FAILED = 0x1770; // 6000
 /** TransferAmountRuleEnforceFailed: Transfer Amount Rule Enforce Failed */
@@ -59,4 +67,23 @@ export function getWenTransferGuardErrorMessage(
   }
 
   return 'Error message not available in production bundles.';
+}
+
+export function isWenTransferGuardError<
+  TProgramErrorCode extends WenTransferGuardError,
+>(
+  error: unknown,
+  transactionMessage: {
+    instructions: Record<number, { programAddress: Address }>;
+  },
+  code?: TProgramErrorCode
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
+  context: { code: TProgramErrorCode };
+} {
+  return isProgramError<TProgramErrorCode>(
+    error,
+    transactionMessage,
+    WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    code
+  );
 }

--- a/packages/renderers-js/e2e/system/src/generated/errors/system.ts
+++ b/packages/renderers-js/e2e/system/src/generated/errors/system.ts
@@ -6,6 +6,14 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
+import {
+  isProgramError,
+  type Address,
+  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+  type SolanaError,
+} from '@solana/web3.js';
+import { SYSTEM_PROGRAM_ADDRESS } from '../programs';
+
 /** AccountAlreadyInUse: an account with the same address already exists */
 export const SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE = 0x0; // 0
 /** ResultWithNegativeLamports: account does not have enough SOL to perform the operation */
@@ -57,4 +65,21 @@ export function getSystemErrorMessage(code: SystemError): string {
   }
 
   return 'Error message not available in production bundles.';
+}
+
+export function isSystemError<TProgramErrorCode extends SystemError>(
+  error: unknown,
+  transactionMessage: {
+    instructions: Record<number, { programAddress: Address }>;
+  },
+  code?: TProgramErrorCode
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
+  context: { code: TProgramErrorCode };
+} {
+  return isProgramError<TProgramErrorCode>(
+    error,
+    transactionMessage,
+    SYSTEM_PROGRAM_ADDRESS,
+    code
+  );
 }

--- a/packages/renderers-js/e2e/system/src/generated/errors/system.ts
+++ b/packages/renderers-js/e2e/system/src/generated/errors/system.ts
@@ -73,9 +73,8 @@ export function isSystemError<TProgramErrorCode extends SystemError>(
     instructions: Record<number, { programAddress: Address }>;
   },
   code?: TProgramErrorCode
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
-  context: { code: TProgramErrorCode };
-} {
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
+  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
   return isProgramError<TProgramErrorCode>(
     error,
     transactionMessage,

--- a/packages/renderers-js/e2e/system/test/transferSol.test.ts
+++ b/packages/renderers-js/e2e/system/test/transferSol.test.ts
@@ -3,13 +3,18 @@ import {
   type Address,
   appendTransactionMessageInstruction,
   generateKeyPairSigner,
+  isSolanaError,
   lamports,
   pipe,
+  SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+  SolanaError,
 } from '@solana/web3.js';
 import test from 'ava';
 import {
   getTransferSolInstruction,
+  isSystemError,
   parseTransferSolInstruction,
+  SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS,
 } from '../src/index.js';
 import {
   createDefaultSolanaClient,
@@ -44,6 +49,54 @@ test('it transfers SOL from one account to another', async (t) => {
 
   // And the destination account has exactly 1 SOL.
   t.is(await getBalance(client, destination), lamports(1_000_000_000n));
+});
+
+test('it fails if the source account does not have enough SOLs', async (t) => {
+  // Given a source account with 1 SOL and a destination account with no SOL.
+  const client = createDefaultSolanaClient();
+  const source = await generateKeyPairSignerWithSol(client, 1_000_000_000n);
+  const destination = (await generateKeyPairSigner()).address;
+
+  // When the source account tries to transfer 2 SOLs to the destination account.
+  const transferSol = getTransferSolInstruction({
+    source,
+    destination,
+    amount: 2_000_000_000,
+  });
+  const txMessage = pipe(await createDefaultTransaction(client, source), (tx) =>
+    appendTransactionMessageInstruction(transferSol, tx)
+  );
+  const promise = signAndSendTransaction(client, txMessage);
+
+  // Then we expect the transaction to fail and to have the correct error code.
+  const error = await t.throwsAsync(promise);
+  if (
+    isSolanaError(
+      error,
+      SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE
+    )
+  ) {
+    if (isSystemError(error.cause, txMessage)) {
+      error satisfies SolanaError;
+      if (
+        isSystemError(
+          error.cause,
+          txMessage,
+          SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS
+        )
+      ) {
+        error.cause.context
+          .code satisfies typeof SYSTEM_ERROR__RESULT_WITH_NEGATIVE_LAMPORTS;
+        t.pass();
+      } else {
+        t.fail('Expected a negative lamports system program error');
+      }
+    } else {
+      t.fail('Expected a system program error');
+    }
+  } else {
+    t.fail('Expected a preflight failure');
+  }
 });
 
 test('it parses the accounts and the data of an existing transfer SOL instruction', async (t) => {

--- a/packages/renderers-js/e2e/token/src/generated/errors/associatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/errors/associatedToken.ts
@@ -6,6 +6,14 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
+import {
+  isProgramError,
+  type Address,
+  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+  type SolanaError,
+} from '@solana/web3.js';
+import { ASSOCIATED_TOKEN_PROGRAM_ADDRESS } from '../programs';
+
 /** InvalidOwner: Associated token account owner does not match address derivation */
 export const ASSOCIATED_TOKEN_ERROR__INVALID_OWNER = 0x0; // 0
 
@@ -30,4 +38,23 @@ export function getAssociatedTokenErrorMessage(
   }
 
   return 'Error message not available in production bundles.';
+}
+
+export function isAssociatedTokenError<
+  TProgramErrorCode extends AssociatedTokenError,
+>(
+  error: unknown,
+  transactionMessage: {
+    instructions: Record<number, { programAddress: Address }>;
+  },
+  code?: TProgramErrorCode
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
+  context: { code: TProgramErrorCode };
+} {
+  return isProgramError<TProgramErrorCode>(
+    error,
+    transactionMessage,
+    ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    code
+  );
 }

--- a/packages/renderers-js/e2e/token/src/generated/errors/associatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/errors/associatedToken.ts
@@ -48,9 +48,8 @@ export function isAssociatedTokenError<
     instructions: Record<number, { programAddress: Address }>;
   },
   code?: TProgramErrorCode
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
-  context: { code: TProgramErrorCode };
-} {
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
+  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
   return isProgramError<TProgramErrorCode>(
     error,
     transactionMessage,

--- a/packages/renderers-js/e2e/token/src/generated/errors/token.ts
+++ b/packages/renderers-js/e2e/token/src/generated/errors/token.ts
@@ -117,9 +117,8 @@ export function isTokenError<TProgramErrorCode extends TokenError>(
     instructions: Record<number, { programAddress: Address }>;
   },
   code?: TProgramErrorCode
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
-  context: { code: TProgramErrorCode };
-} {
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> &
+  Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
   return isProgramError<TProgramErrorCode>(
     error,
     transactionMessage,

--- a/packages/renderers-js/e2e/token/src/generated/errors/token.ts
+++ b/packages/renderers-js/e2e/token/src/generated/errors/token.ts
@@ -6,6 +6,14 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
+import {
+  isProgramError,
+  type Address,
+  type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM,
+  type SolanaError,
+} from '@solana/web3.js';
+import { TOKEN_PROGRAM_ADDRESS } from '../programs';
+
 /** NotRentExempt: Lamport balance below rent-exempt threshold */
 export const TOKEN_ERROR__NOT_RENT_EXEMPT = 0x0; // 0
 /** InsufficientFunds: Insufficient funds */
@@ -101,4 +109,21 @@ export function getTokenErrorMessage(code: TokenError): string {
   }
 
   return 'Error message not available in production bundles.';
+}
+
+export function isTokenError<TProgramErrorCode extends TokenError>(
+  error: unknown,
+  transactionMessage: {
+    instructions: Record<number, { programAddress: Address }>;
+  },
+  code?: TProgramErrorCode
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & {
+  context: { code: TProgramErrorCode };
+} {
+  return isProgramError<TProgramErrorCode>(
+    error,
+    transactionMessage,
+    TOKEN_PROGRAM_ADDRESS,
+    code
+  );
 }

--- a/packages/renderers-js/public/templates/fragments/programErrors.njk
+++ b/packages/renderers-js/public/templates/fragments/programErrors.njk
@@ -31,6 +31,6 @@ export function {{ programIsErrorFunction }}<TProgramErrorCode extends {{ progra
     error: unknown,
     transactionMessage: { instructions: Record<number, { programAddress: Address }> },
     code?: TProgramErrorCode,
-): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: TProgramErrorCode } } {
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & Readonly<{ context: Readonly<{ code: TProgramErrorCode }> }> {
   return isProgramError<TProgramErrorCode>(error, transactionMessage, {{ programAddressConstant }}, code);
 }

--- a/packages/renderers-js/public/templates/fragments/programErrors.njk
+++ b/packages/renderers-js/public/templates/fragments/programErrors.njk
@@ -26,3 +26,11 @@ export function {{ programGetErrorMessageFunction }}(code: {{ programErrorUnion 
 
   return 'Error message not available in production bundles.';
 }
+
+export function {{ programIsErrorFunction }}<TProgramErrorCode extends {{ programErrorUnion }}>(
+    error: unknown,
+    transactionMessage: { instructions: Record<number, { programAddress: Address }> },
+    code?: TProgramErrorCode,
+): error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM> & { context: { code: TProgramErrorCode } } {
+  return isProgramError<TProgramErrorCode>(error, transactionMessage, {{ programAddressConstant }}, code);
+}

--- a/packages/renderers-js/src/ImportMap.ts
+++ b/packages/renderers-js/src/ImportMap.ts
@@ -10,8 +10,10 @@ const DEFAULT_EXTERNAL_MODULE_MAP: Record<string, string> = {
     solanaCodecsDataStructures: '@solana/web3.js',
     solanaCodecsNumbers: '@solana/web3.js',
     solanaCodecsStrings: '@solana/web3.js',
+    solanaErrors: '@solana/web3.js',
     solanaInstructions: '@solana/web3.js',
     solanaOptions: '@solana/web3.js',
+    solanaPrograms: '@solana/web3.js',
     solanaSigners: '@solana/web3.js',
 };
 
@@ -22,8 +24,10 @@ const DEFAULT_GRANULAR_EXTERNAL_MODULE_MAP: Record<string, string> = {
     solanaCodecsDataStructures: '@solana/codecs',
     solanaCodecsNumbers: '@solana/codecs',
     solanaCodecsStrings: '@solana/codecs',
+    solanaErrors: '@solana/errors',
     solanaInstructions: '@solana/instructions',
     solanaOptions: '@solana/codecs',
+    solanaPrograms: '@solana/programs',
     solanaSigners: '@solana/signers',
 };
 

--- a/packages/renderers-js/src/fragments/programErrors.ts
+++ b/packages/renderers-js/src/fragments/programErrors.ts
@@ -9,12 +9,19 @@ export function getProgramErrorsFragment(
     },
 ): Fragment {
     const { programNode, nameApi } = scope;
+    const programAddressConstant = nameApi.programAddressConstant(programNode.name);
     return fragmentFromTemplate('programErrors.njk', {
         errors: programNode.errors,
         getProgramErrorConstant: (name: string) =>
             nameApi.programErrorConstantPrefix(programNode.name) + nameApi.programErrorConstant(name),
+        programAddressConstant,
         programErrorMessagesMap: nameApi.programErrorMessagesMap(programNode.name),
         programErrorUnion: nameApi.programErrorUnion(programNode.name),
         programGetErrorMessageFunction: nameApi.programGetErrorMessageFunction(programNode.name),
-    });
+        programIsErrorFunction: nameApi.programIsErrorFunction(programNode.name),
+    })
+        .addImports('generatedPrograms', [programAddressConstant])
+        .addImports('solanaPrograms', ['isProgramError'])
+        .addImports('solanaErrors', ['type SolanaError', 'type SOLANA_ERROR__INSTRUCTION_ERROR__CUSTOM'])
+        .addImports('solanaAddresses', ['type Address']);
 }

--- a/packages/renderers-js/src/nameTransformers.ts
+++ b/packages/renderers-js/src/nameTransformers.ts
@@ -54,6 +54,7 @@ export type NameTransformerKey =
     | 'programInstructionsEnumVariant'
     | 'programInstructionsIdentifierFunction'
     | 'programInstructionsParsedUnionType'
+    | 'programIsErrorFunction'
     | 'resolverFunction';
 
 export type NameTransformers = Record<NameTransformerKey, NameTransformer>;
@@ -117,5 +118,6 @@ export const DEFAULT_NAME_TRANSFORMERS: NameTransformers = {
     programInstructionsEnumVariant: name => `${pascalCase(name)}`,
     programInstructionsIdentifierFunction: name => `identify${pascalCase(name)}Instruction`,
     programInstructionsParsedUnionType: name => `Parsed${pascalCase(name)}Instruction`,
+    programIsErrorFunction: name => `is${pascalCase(name)}Error`,
     resolverFunction: name => `${camelCase(name)}`,
 };


### PR DESCRIPTION
This PR generates a new helper function in the JS renderer that wraps `isProgramError` from `@solana/programs` such that, the error code type is known and the program address must not be provided.

Here's an example using the system program.

```ts
// Before.
isProgramError(error, txMessage, SYSTEM_PROGRAM_ADDRESS, SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE);

// After.
isSystemError(error, txMessage, SYSTEM_ERROR__ACCOUNT_ALREADY_IN_USE);
```

Here's another example without passing an explicit code expectation. For it to work with `isProgramError` a type parameter must be provided. With the generated helper, this is no longer needed.

```ts
// Before.
isProgramError<SystemError>(error, txMessage, SYSTEM_PROGRAM_ADDRESS);

// After.
isSystemError(error, txMessage);
```