### PR TITLE
Use ReadonlyUint8Array for identifying accounts/instructions by data

### DIFF
--- a/.changeset/shaggy-shrimps-call.md
+++ b/.changeset/shaggy-shrimps-call.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-js': patch
+---
+
+Use ReadonlyUint8Array for identifying accounts/instructions by data

--- a/packages/renderers-js/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -11,6 +11,7 @@ import {
   fixEncoderSize,
   getBytesEncoder,
   type Address,
+  type ReadonlyUint8Array,
 } from '@solana/web3.js';
 import {
   type ParsedCreateGuardInstruction,
@@ -27,9 +28,9 @@ export enum WenTransferGuardAccount {
 }
 
 export function identifyWenTransferGuardAccount(
-  account: { data: Uint8Array } | Uint8Array
+  account: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): WenTransferGuardAccount {
-  const data = account instanceof Uint8Array ? account : account.data;
+  const data = 'data' in account ? account.data : account;
   if (
     containsBytes(
       data,

--- a/packages/renderers-js/e2e/anchor/src/generated/programs/wenTransferGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/programs/wenTransferGuard.ts
@@ -55,10 +55,9 @@ export enum WenTransferGuardInstruction {
 }
 
 export function identifyWenTransferGuardInstruction(
-  instruction: { data: Uint8Array } | Uint8Array
+  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): WenTransferGuardInstruction {
-  const data =
-    instruction instanceof Uint8Array ? instruction : instruction.data;
+  const data = 'data' in instruction ? instruction.data : instruction;
   if (
     containsBytes(
       data,

--- a/packages/renderers-js/e2e/system/src/generated/programs/system.ts
+++ b/packages/renderers-js/e2e/system/src/generated/programs/system.ts
@@ -6,7 +6,12 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
-import { containsBytes, getU32Encoder, type Address } from '@solana/web3.js';
+import {
+  containsBytes,
+  getU32Encoder,
+  type Address,
+  type ReadonlyUint8Array,
+} from '@solana/web3.js';
 import {
   type ParsedAdvanceNonceAccountInstruction,
   type ParsedAllocateInstruction,
@@ -47,10 +52,9 @@ export enum SystemInstruction {
 }
 
 export function identifySystemInstruction(
-  instruction: { data: Uint8Array } | Uint8Array
+  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): SystemInstruction {
-  const data =
-    instruction instanceof Uint8Array ? instruction : instruction.data;
+  const data = 'data' in instruction ? instruction.data : instruction;
   if (containsBytes(data, getU32Encoder().encode(0), 0)) {
     return SystemInstruction.CreateAccount;
   }

--- a/packages/renderers-js/e2e/token/src/generated/programs/associatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/programs/associatedToken.ts
@@ -6,7 +6,12 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
-import { containsBytes, getU8Encoder, type Address } from '@solana/web3.js';
+import {
+  containsBytes,
+  getU8Encoder,
+  type Address,
+  type ReadonlyUint8Array,
+} from '@solana/web3.js';
 import {
   type ParsedCreateAssociatedTokenIdempotentInstruction,
   type ParsedCreateAssociatedTokenInstruction,
@@ -23,10 +28,9 @@ export enum AssociatedTokenInstruction {
 }
 
 export function identifyAssociatedTokenInstruction(
-  instruction: { data: Uint8Array } | Uint8Array
+  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): AssociatedTokenInstruction {
-  const data =
-    instruction instanceof Uint8Array ? instruction : instruction.data;
+  const data = 'data' in instruction ? instruction.data : instruction;
   if (containsBytes(data, getU8Encoder().encode(0), 0)) {
     return AssociatedTokenInstruction.CreateAssociatedToken;
   }

--- a/packages/renderers-js/e2e/token/src/generated/programs/system.ts
+++ b/packages/renderers-js/e2e/token/src/generated/programs/system.ts
@@ -6,7 +6,12 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
-import { containsBytes, getU32Encoder, type Address } from '@solana/web3.js';
+import {
+  containsBytes,
+  getU32Encoder,
+  type Address,
+  type ReadonlyUint8Array,
+} from '@solana/web3.js';
 import { type ParsedCreateAccountInstruction } from '../instructions';
 
 export const SYSTEM_PROGRAM_ADDRESS =
@@ -17,10 +22,9 @@ export enum SystemInstruction {
 }
 
 export function identifySystemInstruction(
-  instruction: { data: Uint8Array } | Uint8Array
+  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): SystemInstruction {
-  const data =
-    instruction instanceof Uint8Array ? instruction : instruction.data;
+  const data = 'data' in instruction ? instruction.data : instruction;
   if (containsBytes(data, getU32Encoder().encode(0), 0)) {
     return SystemInstruction.CreateAccount;
   }

--- a/packages/renderers-js/e2e/token/src/generated/programs/token.ts
+++ b/packages/renderers-js/e2e/token/src/generated/programs/token.ts
@@ -6,7 +6,12 @@
  * @see https://github.com/kinobi-so/kinobi
  */
 
-import { containsBytes, getU8Encoder, type Address } from '@solana/web3.js';
+import {
+  containsBytes,
+  getU8Encoder,
+  type Address,
+  type ReadonlyUint8Array,
+} from '@solana/web3.js';
 import {
   type ParsedAmountToUiAmountInstruction,
   type ParsedApproveCheckedInstruction,
@@ -45,9 +50,9 @@ export enum TokenAccount {
 }
 
 export function identifyTokenAccount(
-  account: { data: Uint8Array } | Uint8Array
+  account: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): TokenAccount {
-  const data = account instanceof Uint8Array ? account : account.data;
+  const data = 'data' in account ? account.data : account;
   if (data.length === 82) {
     return TokenAccount.Mint;
   }

--- a/packages/renderers-js/e2e/token/src/generated/programs/token.ts
+++ b/packages/renderers-js/e2e/token/src/generated/programs/token.ts
@@ -96,10 +96,9 @@ export enum TokenInstruction {
 }
 
 export function identifyTokenInstruction(
-  instruction: { data: Uint8Array } | Uint8Array
+  instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): TokenInstruction {
-  const data =
-    instruction instanceof Uint8Array ? instruction : instruction.data;
+  const data = 'data' in instruction ? instruction.data : instruction;
   if (containsBytes(data, getU8Encoder().encode(0), 0)) {
     return TokenInstruction.InitializeMint;
   }

--- a/packages/renderers-js/src/fragments/programAccounts.ts
+++ b/packages/renderers-js/src/fragments/programAccounts.ts
@@ -57,14 +57,16 @@ function getProgramAccountsIdentifierFunctionFragment(
         r => r.join('\n'),
     );
 
-    return discriminatorsFragment.mapRender(
-        discriminators =>
-            `export function ${programAccountsIdentifierFunction}(` +
-            `account: { data: Uint8Array } | Uint8Array` +
-            `): ${programAccountsEnum} {\n` +
-            `const data = account instanceof Uint8Array ? account : account.data;\n` +
-            `${discriminators}\n` +
-            `throw new Error("The provided account could not be identified as a ${programNode.name} account.")\n` +
-            `}`,
-    );
+    return discriminatorsFragment
+        .mapRender(
+            discriminators =>
+                `export function ${programAccountsIdentifierFunction}(` +
+                `account: { data: ReadonlyUint8Array } | ReadonlyUint8Array` +
+                `): ${programAccountsEnum} {\n` +
+                `const data = 'data' in account ? account.data : account;\n` +
+                `${discriminators}\n` +
+                `throw new Error("The provided account could not be identified as a ${programNode.name} account.")\n` +
+                `}`,
+        )
+        .addImports('solanaCodecsCore', 'type ReadonlyUint8Array');
 }

--- a/packages/renderers-js/src/fragments/programInstructions.ts
+++ b/packages/renderers-js/src/fragments/programInstructions.ts
@@ -75,16 +75,18 @@ function getProgramInstructionsIdentifierFunctionFragment(
         r => r.join('\n'),
     );
 
-    return discriminatorsFragment.mapRender(
-        discriminators =>
-            `export function ${programInstructionsIdentifierFunction}(` +
-            `instruction: { data: Uint8Array } | Uint8Array` +
-            `): ${programInstructionsEnum} {\n` +
-            `const data = instruction instanceof Uint8Array ? instruction : instruction.data;\n` +
-            `${discriminators}\n` +
-            `throw new Error("The provided instruction could not be identified as a ${programNode.name} instruction.")\n` +
-            `}`,
-    );
+    return discriminatorsFragment
+        .mapRender(
+            discriminators =>
+                `export function ${programInstructionsIdentifierFunction}(` +
+                `instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array` +
+                `): ${programInstructionsEnum} {\n` +
+                `const data = 'data' in instruction ? instruction.data : instruction;\n` +
+                `${discriminators}\n` +
+                `throw new Error("The provided instruction could not be identified as a ${programNode.name} instruction.")\n` +
+                `}`,
+        )
+        .addImports('solanaCodecsCore', 'type ReadonlyUint8Array');
 }
 
 function getProgramInstructionsParsedUnionTypeFragment(

--- a/packages/renderers-js/test/programsPage.test.ts
+++ b/packages/renderers-js/test/programsPage.test.ts
@@ -91,8 +91,8 @@ test('it renders an function that identifies accounts in a program', async () =>
     // Then we expect the following identifier function to be rendered.
     // Notice it does not include the `mint` account because it has no discriminators.
     await renderMapContains(renderMap, 'programs/splToken.ts', [
-        `export function identifySplTokenAccount( account: { data: Uint8Array } | Uint8Array ): SplTokenAccount { ` +
-            `const data = account instanceof Uint8Array ? account : account.data; ` +
+        `export function identifySplTokenAccount( account: { data: ReadonlyUint8Array } | ReadonlyUint8Array ): SplTokenAccount { ` +
+            `const data = 'data' in account ? account.data : account; ` +
             `if ( containsBytes(data, getU8Encoder().encode(5), 0) ) { return SplTokenAccount.Metadata; } ` +
             `if ( data.length === 72 && containsBytes(data, new Uint8Array([1, 2, 3]), 4) ) { return SplTokenAccount.Token; } ` +
             `throw new Error ( 'The provided account could not be identified as a splToken account.' ); ` +
@@ -101,7 +101,7 @@ test('it renders an function that identifies accounts in a program', async () =>
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
-        '@solana/web3.js': ['containsBytes'],
+        '@solana/web3.js': ['containsBytes', 'ReadonlyUint8Array'],
     });
 });
 

--- a/packages/renderers-js/test/programsPage.test.ts
+++ b/packages/renderers-js/test/programsPage.test.ts
@@ -163,8 +163,8 @@ test('it renders an function that identifies instructions in a program', async (
     // Then we expect the following identifier function to be rendered.
     // Notice it does not include the `updateAuthority` instruction because it has no discriminators.
     await renderMapContains(renderMap, 'programs/splToken.ts', [
-        `export function identifySplTokenInstruction ( instruction: { data: Uint8Array } | Uint8Array ): SplTokenInstruction { ` +
-            `const data = instruction instanceof Uint8Array ? instruction : instruction.data; ` +
+        `export function identifySplTokenInstruction ( instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array ): SplTokenInstruction { ` +
+            `const data = 'data' in instruction ? instruction.data : instruction; ` +
             `if ( containsBytes(data, getU8Encoder().encode(1), 0) ) { return SplTokenInstruction.MintTokens; } ` +
             `if ( data.length === 72 && containsBytes(data, new Uint8Array([1, 2, 3]), 4) ) { return SplTokenInstruction.TransferTokens; } ` +
             `throw new Error( 'The provided instruction could not be identified as a splToken instruction.' ); ` +
@@ -173,7 +173,7 @@ test('it renders an function that identifies instructions in a program', async (
 
     // And we expect the following imports.
     await renderMapContainsImports(renderMap, 'programs/splToken.ts', {
-        '@solana/web3.js': ['containsBytes'],
+        '@solana/web3.js': ['containsBytes', 'ReadonlyUint8Array'],
     });
 });
 


### PR DESCRIPTION
The `identifyXInstruction` and `identifyXAccount` already accept a `Uint8Array` that can be used to identify an instruction given just the data byte array. But if this comes from a web3js encoder (eg encoding base64 data from somewhere else), then the datatype will be `ReadonlyUint8Array` instead. 

This PR updates these identify functions to allow an input of `ReadonlyUint8Array` instead. This doesn't require any further changes, as everything being done with data is already compatible with `ReadonlyUint8Array`. It's also backward compatible, you can still pass a `Uint8Array` in. 

This means that output from our encoders can now be passed directly to these generated instructions. 