### PR TITLE
Support type aliases from DefinedTypeNodes in Rust renderer

### DIFF
--- a/.changeset/brave-pens-float.md
+++ b/.changeset/brave-pens-float.md
@@ -1,0 +1,5 @@
+---
+"@kinobi-so/renderers-rust": patch
+---
+
+Support type aliases from `DefinedTypeNodes`

--- a/packages/renderers-rust/test/types/array.test.ts
+++ b/packages/renderers-rust/test/types/array.test.ts
@@ -11,9 +11,31 @@ import { visit } from '@kinobi-so/visitors-core';
 import { test } from 'vitest';
 
 import { getRenderMapVisitor } from '../../src';
-import { codeContains } from '../_setup';
+import { codeContains, codeDoesNotContains } from '../_setup';
 
 test('it exports short vecs', () => {
+    // Given an array using a shortU16 prefix.
+    const node = definedTypeNode({
+        name: 'myShortVec',
+        type: arrayTypeNode(publicKeyTypeNode(), prefixedCountNode(numberTypeNode('shortU16'))),
+    });
+
+    // When we render the array.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect a short vec to be exported.
+    codeContains(renderMap.get('types/my_short_vec.rs'), [
+        /pub type MyShortVec = ShortVec<Pubkey>/,
+        /use solana_program::pubkey::Pubkey/,
+        /use solana_program::short_vec::ShortVec/,
+    ]);
+    codeDoesNotContains(renderMap.get('types/my_short_vec.rs'), [
+        /use borsh::BorshSerialize/,
+        /use borsh::BorshDeserialize/,
+    ]);
+});
+
+test('it exports short vecs as struct fields', () => {
     // Given an array using a shortU16 prefix.
     const node = definedTypeNode({
         name: 'myShortVec',
@@ -28,7 +50,7 @@ test('it exports short vecs', () => {
     // When we render the array.
     const renderMap = visit(node, getRenderMapVisitor());
 
-    // Then we expect a short vec to be exported.
+    // Then we expect a short vec to be exported as a struct field.
     codeContains(renderMap.get('types/my_short_vec.rs'), [
         /pub value: ShortVec<Pubkey>/,
         /use solana_program::pubkey::Pubkey/,

--- a/packages/renderers-rust/test/types/number.test.ts
+++ b/packages/renderers-rust/test/types/number.test.ts
@@ -3,9 +3,30 @@ import { visit } from '@kinobi-so/visitors-core';
 import { test } from 'vitest';
 
 import { getRenderMapVisitor } from '../../src';
-import { codeContains } from '../_setup';
+import { codeContains, codeDoesNotContains } from '../_setup';
 
 test('it exports short u16 numbers', () => {
+    // Given a shortU16 number.
+    const node = definedTypeNode({
+        name: 'myShortU16',
+        type: numberTypeNode('shortU16'),
+    });
+
+    // When we render the number.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect a short u16 to be exported.
+    codeContains(renderMap.get('types/my_short_u16.rs'), [
+        /pub type MyShortU16 = ShortU16/,
+        /use solana_program::short_vec::ShortU16/,
+    ]);
+    codeDoesNotContains(renderMap.get('types/my_short_u16.rs'), [
+        /use borsh::BorshSerialize/,
+        /use borsh::BorshDeserialize/,
+    ]);
+});
+
+test('it exports short u16 numbers as struct fields', () => {
     // Given a shortU16 number.
     const node = definedTypeNode({
         name: 'myShortU16',
@@ -15,7 +36,7 @@ test('it exports short u16 numbers', () => {
     // When we render the number.
     const renderMap = visit(node, getRenderMapVisitor());
 
-    // Then we expect a short u16 to be exported.
+    // Then we expect a short u16 to be exported as a struct field.
     codeContains(renderMap.get('types/my_short_u16.rs'), [
         /pub value: ShortU16/,
         /use solana_program::short_vec::ShortU16/,


### PR DESCRIPTION
Currently, the Rust renderer can only render `DefinedTypeNodes` if the child type is a `StructTypeNode` or an `EnumTypeNode`.

This PR allows any other child type to be rendered as a Rust type alias like so.

```rust
pub type MyAlias = ShortVec<Pubkey>;
```