### PR TITLE
Render sol amount as lamports

### DIFF
--- a/.changeset/cyan-badgers-stare.md
+++ b/.changeset/cyan-badgers-stare.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-js': patch
+---
+
+Use lamports type/encoder/decoder for SolAmountTypeNode

--- a/packages/renderers-js/e2e/system/idl.json
+++ b/packages/renderers-js/e2e/system/idl.json
@@ -37,9 +37,12 @@
               "kind": "structFieldTypeNode",
               "name": "lamportsPerSignature",
               "type": {
-                "kind": "numberTypeNode",
-                "format": "u64",
-                "endian": "le"
+                "kind": "solAmountTypeNode",
+                "number": {
+                  "kind": "numberTypeNode",
+                  "format": "u64",
+                  "endian": "le"
+                }
               },
               "docs": []
             }
@@ -90,9 +93,12 @@
             "kind": "instructionArgumentNode",
             "name": "lamports",
             "type": {
-              "kind": "numberTypeNode",
-              "format": "u64",
-              "endian": "le"
+              "kind": "solAmountTypeNode",
+              "number": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              }
             },
             "docs": []
           },

--- a/packages/renderers-js/e2e/system/src/generated/accounts/nonce.ts
+++ b/packages/renderers-js/e2e/system/src/generated/accounts/nonce.ts
@@ -15,6 +15,8 @@ import {
   fetchEncodedAccounts,
   getAddressDecoder,
   getAddressEncoder,
+  getLamportsDecoder,
+  getLamportsEncoder,
   getStructDecoder,
   getStructEncoder,
   getU64Decoder,
@@ -27,6 +29,7 @@ import {
   type Encoder,
   type FetchAccountConfig,
   type FetchAccountsConfig,
+  type LamportsUnsafeBeyond2Pow53Minus1,
   type MaybeAccount,
   type MaybeEncodedAccount,
 } from '@solana/web3.js';
@@ -46,7 +49,7 @@ export type Nonce = {
   state: NonceState;
   authority: Address;
   blockhash: Address;
-  lamportsPerSignature: bigint;
+  lamportsPerSignature: LamportsUnsafeBeyond2Pow53Minus1;
 };
 
 export type NonceArgs = {
@@ -54,7 +57,7 @@ export type NonceArgs = {
   state: NonceStateArgs;
   authority: Address;
   blockhash: Address;
-  lamportsPerSignature: number | bigint;
+  lamportsPerSignature: LamportsUnsafeBeyond2Pow53Minus1;
 };
 
 export function getNonceEncoder(): Encoder<NonceArgs> {
@@ -63,7 +66,7 @@ export function getNonceEncoder(): Encoder<NonceArgs> {
     ['state', getNonceStateEncoder()],
     ['authority', getAddressEncoder()],
     ['blockhash', getAddressEncoder()],
-    ['lamportsPerSignature', getU64Encoder()],
+    ['lamportsPerSignature', getLamportsEncoder(getU64Encoder())],
   ]);
 }
 
@@ -73,7 +76,7 @@ export function getNonceDecoder(): Decoder<Nonce> {
     ['state', getNonceStateDecoder()],
     ['authority', getAddressDecoder()],
     ['blockhash', getAddressDecoder()],
-    ['lamportsPerSignature', getU64Decoder()],
+    ['lamportsPerSignature', getLamportsDecoder(getU64Decoder())],
   ]);
 }
 

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -11,6 +11,8 @@ import {
   combineCodec,
   getAddressDecoder,
   getAddressEncoder,
+  getLamportsDecoder,
+  getLamportsEncoder,
   getStructDecoder,
   getStructEncoder,
   getU32Decoder,
@@ -27,6 +29,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type LamportsUnsafeBeyond2Pow53Minus1,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -60,13 +63,13 @@ export type CreateAccountInstruction<
 
 export type CreateAccountInstructionData = {
   discriminator: number;
-  lamports: bigint;
+  lamports: LamportsUnsafeBeyond2Pow53Minus1;
   space: bigint;
   programAddress: Address;
 };
 
 export type CreateAccountInstructionDataArgs = {
-  lamports: number | bigint;
+  lamports: LamportsUnsafeBeyond2Pow53Minus1;
   space: number | bigint;
   programAddress: Address;
 };
@@ -75,7 +78,7 @@ export function getCreateAccountInstructionDataEncoder(): Encoder<CreateAccountI
   return transformEncoder(
     getStructEncoder([
       ['discriminator', getU32Encoder()],
-      ['lamports', getU64Encoder()],
+      ['lamports', getLamportsEncoder(getU64Encoder())],
       ['space', getU64Encoder()],
       ['programAddress', getAddressEncoder()],
     ]),
@@ -86,7 +89,7 @@ export function getCreateAccountInstructionDataEncoder(): Encoder<CreateAccountI
 export function getCreateAccountInstructionDataDecoder(): Decoder<CreateAccountInstructionData> {
   return getStructDecoder([
     ['discriminator', getU32Decoder()],
-    ['lamports', getU64Decoder()],
+    ['lamports', getLamportsDecoder(getU64Decoder())],
     ['space', getU64Decoder()],
     ['programAddress', getAddressDecoder()],
   ]);

--- a/packages/renderers-js/e2e/token/idl.json
+++ b/packages/renderers-js/e2e/token/idl.json
@@ -2800,9 +2800,12 @@
               "kind": "instructionArgumentNode",
               "name": "lamports",
               "type": {
-                "kind": "numberTypeNode",
-                "format": "u64",
-                "endian": "le"
+                "kind": "solAmountTypeNode",
+                "number": {
+                  "kind": "numberTypeNode",
+                  "format": "u64",
+                  "endian": "le"
+                }
               },
               "docs": []
             },

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -11,6 +11,8 @@ import {
   combineCodec,
   getAddressDecoder,
   getAddressEncoder,
+  getLamportsDecoder,
+  getLamportsEncoder,
   getStructDecoder,
   getStructEncoder,
   getU32Decoder,
@@ -27,6 +29,7 @@ import {
   type IInstruction,
   type IInstructionWithAccounts,
   type IInstructionWithData,
+  type LamportsUnsafeBeyond2Pow53Minus1,
   type TransactionSigner,
   type WritableSignerAccount,
 } from '@solana/web3.js';
@@ -60,13 +63,13 @@ export type CreateAccountInstruction<
 
 export type CreateAccountInstructionData = {
   discriminator: number;
-  lamports: bigint;
+  lamports: LamportsUnsafeBeyond2Pow53Minus1;
   space: bigint;
   programAddress: Address;
 };
 
 export type CreateAccountInstructionDataArgs = {
-  lamports: number | bigint;
+  lamports: LamportsUnsafeBeyond2Pow53Minus1;
   space: number | bigint;
   programAddress: Address;
 };
@@ -75,7 +78,7 @@ export function getCreateAccountInstructionDataEncoder(): Encoder<CreateAccountI
   return transformEncoder(
     getStructEncoder([
       ['discriminator', getU32Encoder()],
-      ['lamports', getU64Encoder()],
+      ['lamports', getLamportsEncoder(getU64Encoder())],
       ['space', getU64Encoder()],
       ['programAddress', getAddressEncoder()],
     ]),
@@ -86,7 +89,7 @@ export function getCreateAccountInstructionDataEncoder(): Encoder<CreateAccountI
 export function getCreateAccountInstructionDataDecoder(): Decoder<CreateAccountInstructionData> {
   return getStructDecoder([
     ['discriminator', getU32Decoder()],
-    ['lamports', getU64Decoder()],
+    ['lamports', getLamportsDecoder(getU64Decoder())],
     ['space', getU64Decoder()],
     ['programAddress', getAddressDecoder()],
   ]);

--- a/packages/renderers-js/src/ImportMap.ts
+++ b/packages/renderers-js/src/ImportMap.ts
@@ -14,6 +14,7 @@ const DEFAULT_EXTERNAL_MODULE_MAP: Record<string, string> = {
     solanaInstructions: '@solana/web3.js',
     solanaOptions: '@solana/web3.js',
     solanaPrograms: '@solana/web3.js',
+    solanaRpcTypes: '@solana/web3.js',
     solanaSigners: '@solana/web3.js',
 };
 
@@ -28,6 +29,7 @@ const DEFAULT_GRANULAR_EXTERNAL_MODULE_MAP: Record<string, string> = {
     solanaInstructions: '@solana/instructions',
     solanaOptions: '@solana/codecs',
     solanaPrograms: '@solana/programs',
+    solanaRpcTypes: '@solana/rpc-types',
     solanaSigners: '@solana/signers',
 };
 

--- a/packages/renderers-js/src/getTypeManifestVisitor.ts
+++ b/packages/renderers-js/src/getTypeManifestVisitor.ts
@@ -701,8 +701,26 @@ export function getTypeManifestVisitor(input: {
                     return manifest;
                 },
 
-                visitSolAmountType(solAmountType, { self }) {
-                    return visit(solAmountType.number, self);
+                visitSolAmountType({ number }, { self }) {
+                    const numberManifest = visit(number, self);
+
+                    const lamportsType = 'LamportsUnsafeBeyond2Pow53Minus1';
+                    const lamportsImport = new ImportMap().add(
+                        'solanaRpcTypes',
+                        'type LamportsUnsafeBeyond2Pow53Minus1',
+                    );
+
+                    return {
+                        ...numberManifest,
+                        decoder: numberManifest.decoder
+                            .mapRender(r => `getLamportsDecoder(${r})`)
+                            .addImports('solanaRpcTypes', 'getLamportsDecoder'),
+                        encoder: numberManifest.encoder
+                            .mapRender(r => `getLamportsEncoder(${r})`)
+                            .addImports('solanaRpcTypes', 'getLamportsEncoder'),
+                        looseType: fragment(lamportsType, lamportsImport),
+                        strictType: fragment(lamportsType, lamportsImport),
+                    };
                 },
 
                 visitSomeValue(node, { self }) {

--- a/packages/renderers-js/test/types/solAmount.test.ts
+++ b/packages/renderers-js/test/types/solAmount.test.ts
@@ -1,0 +1,36 @@
+import { definedTypeNode, numberTypeNode, solAmountTypeNode } from '@kinobi-so/nodes';
+import { visit } from '@kinobi-so/visitors-core';
+import { test } from 'vitest';
+
+import { getRenderMapVisitor } from '../../src';
+import { renderMapContains, renderMapContainsImports } from '../_setup';
+
+test('it renders size prefix codecs', async () => {
+    // Given the following node.
+    const node = definedTypeNode({
+        name: 'myType',
+        type: solAmountTypeNode(numberTypeNode('u64')),
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect the following types and codecs to be exported.
+    await renderMapContains(renderMap, 'types/myType.ts', [
+        'export type MyType = LamportsUnsafeBeyond2Pow53Minus1',
+        'export type MyTypeArgs = MyType',
+        'export function getMyTypeEncoder(): Encoder<MyTypeArgs> { return getLamportsEncoder(getU64Encoder()); }',
+        'export function getMyTypeDecoder(): Decoder<MyType> { return getLamportsDecoder(getU64Decoder()); }',
+    ]);
+
+    // And we expect the following type and codec imports.
+    await renderMapContainsImports(renderMap, 'types/myType.ts', {
+        '@solana/web3.js': [
+            'LamportsUnsafeBeyond2Pow53Minus1',
+            'getLamportsEncoder',
+            'getLamportsDecoder',
+            'getU64Encoder',
+            'getU64Decoder',
+        ],
+    });
+});


### PR DESCRIPTION
Note:  #160 is a prerequisite (Graphite 💔)

This PR updates how `SolAmountTypeNode` is rendered in the new web3js renderer. Previously it just rendered its nested number type. It now renders with a `Lamports` type from web3js. The encoder + decoder use `getLamportsEncoder` and `getLamportsDecoder`, passing the nested number encoder/decoder as an argument.

This means that you can represent Lamports in the Kinobi IDL using any numeric type, and you'll get properly typed Lamports back. This can improve eg parsing of instructions like `createAccount` where some arguments represent Lamport values. 