### PR TITLE
[0.22] Add optional program attribute to link nodes

### DIFF
--- a/.changeset/tough-grapes-give.md
+++ b/.changeset/tough-grapes-give.md
@@ -1,0 +1,9 @@
+---
+'@kinobi-so/visitors-core': minor
+'@kinobi-so/node-types': minor
+'@kinobi-so/nodes': minor
+'@kinobi-so/visitors': patch
+'@kinobi-so/errors': patch
+---
+
+Add optional `program` attribute to link nodes and namespace linkable nodes under their associated program.

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -75,6 +75,7 @@ export type KinobiErrorContext = DefaultUnspecifiedErrorContextToUndefined<{
         kind: LinkNode['kind'];
         linkNode: LinkNode;
         name: CamelCaseString;
+        program?: CamelCaseString;
     };
     [KINOBI_ERROR__NODE_FILESYSTEM_FUNCTION_UNAVAILABLE]: {
         fsFunction: string;

--- a/packages/node-types/src/linkNodes/AccountLinkNode.ts
+++ b/packages/node-types/src/linkNodes/AccountLinkNode.ts
@@ -1,7 +1,11 @@
 import type { CamelCaseString } from '../shared';
+import type { ProgramLinkNode } from './ProgramLinkNode';
 
-export interface AccountLinkNode {
+export interface AccountLinkNode<TProgram extends ProgramLinkNode | undefined = ProgramLinkNode | undefined> {
     readonly kind: 'accountLinkNode';
+
+    // Children.
+    readonly program?: TProgram;
 
     // Data.
     readonly name: CamelCaseString;

--- a/packages/node-types/src/linkNodes/DefinedTypeLinkNode.ts
+++ b/packages/node-types/src/linkNodes/DefinedTypeLinkNode.ts
@@ -1,7 +1,11 @@
 import type { CamelCaseString } from '../shared';
+import type { ProgramLinkNode } from './ProgramLinkNode';
 
-export interface DefinedTypeLinkNode {
+export interface DefinedTypeLinkNode<TProgram extends ProgramLinkNode | undefined = ProgramLinkNode | undefined> {
     readonly kind: 'definedTypeLinkNode';
+
+    // Children.
+    readonly program?: TProgram;
 
     // Data.
     readonly name: CamelCaseString;

--- a/packages/node-types/src/linkNodes/PdaLinkNode.ts
+++ b/packages/node-types/src/linkNodes/PdaLinkNode.ts
@@ -1,7 +1,11 @@
 import type { CamelCaseString } from '../shared';
+import type { ProgramLinkNode } from './ProgramLinkNode';
 
-export interface PdaLinkNode {
+export interface PdaLinkNode<TProgram extends ProgramLinkNode | undefined = ProgramLinkNode | undefined> {
     readonly kind: 'pdaLinkNode';
+
+    // Children.
+    readonly program?: TProgram;
 
     // Data.
     readonly name: CamelCaseString;

--- a/packages/nodes/docs/linkNodes/AccountLinkNode.md
+++ b/packages/nodes/docs/linkNodes/AccountLinkNode.md
@@ -13,14 +13,17 @@ This node represents a reference to an existing [`AccountNode`](../AccountNode.m
 
 ### Children
 
-_This node has no children._
+| Attribute | Type                                      | Description                                                                                                     |
+| --------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `program` | [`ProgramLinkNode`](./ProgramLinkNode.md) | (Optional) The program associated with the linked account. Default to using the program we are currently under. |
 
 ## Functions
 
-### `accountLinkNode(name)`
+### `accountLinkNode(name, program?)`
 
-Helper function that creates a `AccountLinkNode` object from the name of the `AccountNode` we are referring to.
+Helper function that creates a `AccountLinkNode` object from the name of the `AccountNode` we are referring to. If the account is from another program, the `program` parameter must be provided as either a `string` or a `ProgramLinkNode`.
 
 ```ts
 const node = accountLinkNode('myAccount');
+const nodeFromAnotherProgram = accountLinkNode('myAccount', 'myOtherProgram');
 ```

--- a/packages/nodes/docs/linkNodes/DefinedTypeLinkNode.md
+++ b/packages/nodes/docs/linkNodes/DefinedTypeLinkNode.md
@@ -13,14 +13,17 @@ This node represents a reference to an existing [`DefinedTypeNode`](../DefinedTy
 
 ### Children
 
-_This node has no children._
+| Attribute | Type                                      | Description                                                                                                  |
+| --------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `program` | [`ProgramLinkNode`](./ProgramLinkNode.md) | (Optional) The program associated with the linked type. Default to using the program we are currently under. |
 
 ## Functions
 
-### `definedTypeLinkNode(name)`
+### `definedTypeLinkNode(name, program?)`
 
-Helper function that creates a `DefinedTypeLinkNode` object from the name of the `DefinedTypeNode` we are referring to.
+Helper function that creates a `DefinedTypeLinkNode` object from the name of the `DefinedTypeNode` we are referring to. If the defined type is from another program, the `program` parameter must be provided as either a `string` or a `ProgramLinkNode`.
 
 ```ts
 const node = definedTypeLinkNode('myDefinedType');
+const nodeFromAnotherProgram = definedTypeLinkNode('myDefinedType', 'myOtherProgram');
 ```

--- a/packages/nodes/docs/linkNodes/PdaLinkNode.md
+++ b/packages/nodes/docs/linkNodes/PdaLinkNode.md
@@ -13,14 +13,17 @@ This node represents a reference to an existing [`PdaNode`](../PdaNode.md) in th
 
 ### Children
 
-_This node has no children._
+| Attribute | Type                                      | Description                                                                                                 |
+| --------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `program` | [`ProgramLinkNode`](./ProgramLinkNode.md) | (Optional) The program associated with the linked PDA. Default to using the program we are currently under. |
 
 ## Functions
 
-### `pdaLinkNode(name)`
+### `pdaLinkNode(name, program?)`
 
-Helper function that creates a `PdaLinkNode` object from the name of the `PdaNode` we are referring to.
+Helper function that creates a `PdaLinkNode` object from the name of the `PdaNode` we are referring to. If the PDA is from another program, the `program` parameter must be provided as either a `string` or a `ProgramLinkNode`.
 
 ```ts
 const node = pdaLinkNode('myPda');
+const nodeFromAnotherProgram = pdaLinkNode('myPda', 'myOtherProgram');
 ```

--- a/packages/nodes/src/linkNodes/AccountLinkNode.ts
+++ b/packages/nodes/src/linkNodes/AccountLinkNode.ts
@@ -1,10 +1,14 @@
-import type { AccountLinkNode } from '@kinobi-so/node-types';
+import type { AccountLinkNode, ProgramLinkNode } from '@kinobi-so/node-types';
 
 import { camelCase } from '../shared';
+import { programLinkNode } from './ProgramLinkNode';
 
-export function accountLinkNode(name: string): AccountLinkNode {
+export function accountLinkNode(name: string, program?: ProgramLinkNode | string): AccountLinkNode {
     return Object.freeze({
         kind: 'accountLinkNode',
+
+        // Children.
+        ...(program === undefined ? {} : { program: typeof program === 'string' ? programLinkNode(program) : program }),
 
         // Data.
         name: camelCase(name),

--- a/packages/nodes/src/linkNodes/DefinedTypeLinkNode.ts
+++ b/packages/nodes/src/linkNodes/DefinedTypeLinkNode.ts
@@ -1,10 +1,14 @@
-import type { DefinedTypeLinkNode } from '@kinobi-so/node-types';
+import type { DefinedTypeLinkNode, ProgramLinkNode } from '@kinobi-so/node-types';
 
 import { camelCase } from '../shared';
+import { programLinkNode } from './ProgramLinkNode';
 
-export function definedTypeLinkNode(name: string): DefinedTypeLinkNode {
+export function definedTypeLinkNode(name: string, program?: ProgramLinkNode | string): DefinedTypeLinkNode {
     return Object.freeze({
         kind: 'definedTypeLinkNode',
+
+        // Children.
+        ...(program === undefined ? {} : { program: typeof program === 'string' ? programLinkNode(program) : program }),
 
         // Data.
         name: camelCase(name),

--- a/packages/nodes/src/linkNodes/PdaLinkNode.ts
+++ b/packages/nodes/src/linkNodes/PdaLinkNode.ts
@@ -1,10 +1,14 @@
-import type { PdaLinkNode } from '@kinobi-so/node-types';
+import type { PdaLinkNode, ProgramLinkNode } from '@kinobi-so/node-types';
 
 import { camelCase } from '../shared';
+import { programLinkNode } from './ProgramLinkNode';
 
-export function pdaLinkNode(name: string): PdaLinkNode {
+export function pdaLinkNode(name: string, program?: ProgramLinkNode | string): PdaLinkNode {
     return Object.freeze({
         kind: 'pdaLinkNode',
+
+        // Children.
+        ...(program === undefined ? {} : { program: typeof program === 'string' ? programLinkNode(program) : program }),
 
         // Data.
         name: camelCase(name),

--- a/packages/visitors-core/README.md
+++ b/packages/visitors-core/README.md
@@ -651,11 +651,11 @@ It offers the following API:
 ```ts
 const linkables = new LinkableDictionary();
 
-// Record any linkable node — such as programs, PDAs, accounts and defined types.
+// Record program nodes.
 linkables.record(programNode);
 
-// Record multiple linkable nodes at once.
-linkables.recordAll([...accountNodes, ...pdaNodes]);
+// Record other linkable nodes with their associated program node.
+linkables.record(accountNode);
 
 // Get a linkable node using a link node, or throw an error if it is not found.
 const programNode = linkables.getOrThrow(programLinkNode);
@@ -663,6 +663,8 @@ const programNode = linkables.getOrThrow(programLinkNode);
 // Get a linkable node using a link node, or return undefined if it is not found.
 const accountNode = linkables.get(accountLinkNode);
 ```
+
+Note that this API must be used in conjunction with the `recordLinkablesVisitor` to record the linkable nodes and, later on, resolve the link nodes as we traverse the nodes. This is because the `LinkableDictionary` instance keeps track of its own internal `NodeStack` in order to understand which program node should be used for a given link node.
 
 ### `recordLinkablesVisitor`
 
@@ -676,14 +678,16 @@ Here's an example that records a `LinkableDictionary` and uses it to log the amo
 const linkables = new LinkableDictionary();
 const visitor = pipe(
     baseVisitor,
-    v => recordLinkablesVisitor(v, linkables),
     v =>
         tapVisitor(v, 'pdaLinkNode', node => {
             const pdaNode = linkables.getOrThrow(node);
             console.log(`${pdaNode.seeds.length} seeds`);
         }),
+    v => recordLinkablesVisitor(v, linkables),
 );
 ```
+
+Note that the `recordLinkablesVisitor` should always be the last visitor in the pipe to ensure that all linkable nodes are recorded before being used.
 
 ## Other useful visitors
 

--- a/packages/visitors-core/src/NodeStack.ts
+++ b/packages/visitors-core/src/NodeStack.ts
@@ -1,4 +1,4 @@
-import { GetNodeFromKind, isNodeFilter, Node, NodeKind, ProgramNode } from '@kinobi-so/nodes';
+import { GetNodeFromKind, isNode, Node, NodeKind, ProgramNode } from '@kinobi-so/nodes';
 
 export class NodeStack {
     private readonly stack: Node[];
@@ -20,7 +20,11 @@ export class NodeStack {
     }
 
     public find<TKind extends NodeKind>(kind: TKind | TKind[]): GetNodeFromKind<TKind> | undefined {
-        return this.stack.find(isNodeFilter(kind));
+        for (let index = this.stack.length - 1; index >= 0; index--) {
+            const node = this.stack[index];
+            if (isNode(node, kind)) return node;
+        }
+        return undefined;
     }
 
     public getProgram(): ProgramNode | undefined {

--- a/packages/visitors-core/src/getDebugStringVisitor.ts
+++ b/packages/visitors-core/src/getDebugStringVisitor.ts
@@ -64,10 +64,11 @@ function getNodeDetails(node: Node): string[] {
         case 'errorNode':
             return [node.code.toString(), node.name];
         case 'programLinkNode':
+            return [node.name];
         case 'pdaLinkNode':
         case 'accountLinkNode':
         case 'definedTypeLinkNode':
-            return [node.name];
+            return [...(node.program ? [node.program.name] : []), node.name];
         case 'numberTypeNode':
             return [node.format, ...(node.endian === 'be' ? ['bigEndian'] : [])];
         case 'amountTypeNode':

--- a/packages/visitors-core/src/recordLinkablesVisitor.ts
+++ b/packages/visitors-core/src/recordLinkablesVisitor.ts
@@ -3,6 +3,8 @@ import { isNode, type NodeKind } from '@kinobi-so/nodes';
 import { interceptFirstVisitVisitor } from './interceptFirstVisitVisitor';
 import { interceptVisitor } from './interceptVisitor';
 import { LINKABLE_NODES, LinkableDictionary } from './LinkableDictionary';
+import { pipe } from './pipe';
+import { recordNodeStackVisitor } from './recordNodeStackVisitor';
 import { visit, Visitor } from './visitor';
 import { voidVisitor } from './voidVisitor';
 
@@ -10,15 +12,25 @@ export function recordLinkablesVisitor<TReturn, TNodeKind extends NodeKind>(
     visitor: Visitor<TReturn, TNodeKind>,
     linkables: LinkableDictionary,
 ): Visitor<TReturn, TNodeKind> {
-    const recordingVisitor = interceptVisitor(voidVisitor(), (node, next) => {
-        if (isNode(node, LINKABLE_NODES)) {
-            linkables.record(node);
-        }
-        return next(node);
-    });
+    const recordingVisitor = pipe(
+        voidVisitor(),
+        v =>
+            interceptVisitor(v, (node, next) => {
+                if (isNode(node, LINKABLE_NODES)) {
+                    linkables.record(node);
+                }
+                return next(node);
+            }),
+        v => recordNodeStackVisitor(v, linkables.stack),
+    );
 
-    return interceptFirstVisitVisitor(visitor, (node, next) => {
-        visit(node, recordingVisitor);
-        return next(node);
-    });
+    return pipe(
+        visitor,
+        v =>
+            interceptFirstVisitVisitor(v, (node, next) => {
+                visit(node, recordingVisitor);
+                return next(node);
+            }),
+        v => recordNodeStackVisitor(v, linkables.stack),
+    );
 }

--- a/packages/visitors-core/test/nodes/linkNodes/AccountLinkNode.test.ts
+++ b/packages/visitors-core/test/nodes/linkNodes/AccountLinkNode.test.ts
@@ -8,7 +8,7 @@ import {
     expectMergeVisitorCount,
 } from '../_setup';
 
-const node = accountLinkNode('token');
+const node = accountLinkNode('token', 'splToken');
 
 test('mergeVisitor', () => {
     expectMergeVisitorCount(node, 1);
@@ -23,5 +23,5 @@ test('deleteNodesVisitor', () => {
 });
 
 test('debugStringVisitor', () => {
-    expectDebugStringVisitor(node, `accountLinkNode [token]`);
+    expectDebugStringVisitor(node, `accountLinkNode [splToken.token]`);
 });

--- a/packages/visitors-core/test/nodes/linkNodes/DefinedTypeLinkNode.test.ts
+++ b/packages/visitors-core/test/nodes/linkNodes/DefinedTypeLinkNode.test.ts
@@ -8,7 +8,7 @@ import {
     expectMergeVisitorCount,
 } from '../_setup';
 
-const node = definedTypeLinkNode('tokenState');
+const node = definedTypeLinkNode('tokenState', 'splToken');
 
 test('mergeVisitor', () => {
     expectMergeVisitorCount(node, 1);
@@ -23,5 +23,5 @@ test('deleteNodesVisitor', () => {
 });
 
 test('debugStringVisitor', () => {
-    expectDebugStringVisitor(node, `definedTypeLinkNode [tokenState]`);
+    expectDebugStringVisitor(node, `definedTypeLinkNode [splToken.tokenState]`);
 });

--- a/packages/visitors-core/test/nodes/linkNodes/PdaLinkNode.test.ts
+++ b/packages/visitors-core/test/nodes/linkNodes/PdaLinkNode.test.ts
@@ -8,7 +8,7 @@ import {
     expectMergeVisitorCount,
 } from '../_setup';
 
-const node = pdaLinkNode('associatedToken');
+const node = pdaLinkNode('associatedToken', 'splToken');
 
 test('mergeVisitor', () => {
     expectMergeVisitorCount(node, 1);
@@ -23,5 +23,5 @@ test('deleteNodesVisitor', () => {
 });
 
 test('debugStringVisitor', () => {
-    expectDebugStringVisitor(node, `pdaLinkNode [associatedToken]`);
+    expectDebugStringVisitor(node, `pdaLinkNode [splToken.associatedToken]`);
 });

--- a/packages/visitors-core/test/recordLinkablesVisitor.test.ts
+++ b/packages/visitors-core/test/recordLinkablesVisitor.test.ts
@@ -1,8 +1,10 @@
 import {
     accountLinkNode,
+    AccountNode,
     accountNode,
     definedTypeLinkNode,
     definedTypeNode,
+    isNode,
     pdaLinkNode,
     pdaNode,
     programLinkNode,
@@ -12,7 +14,14 @@ import {
 } from '@kinobi-so/nodes';
 import { expect, test } from 'vitest';
 
-import { interceptFirstVisitVisitor, LinkableDictionary, recordLinkablesVisitor, visit, voidVisitor } from '../src';
+import {
+    interceptFirstVisitVisitor,
+    interceptVisitor,
+    LinkableDictionary,
+    recordLinkablesVisitor,
+    visit,
+    voidVisitor,
+} from '../src';
 
 test('it record all linkable nodes it finds when traversing the tree', () => {
     // Given the following root node containing multiple linkable nodes.
@@ -45,12 +54,12 @@ test('it record all linkable nodes it finds when traversing the tree', () => {
     // Then we expect all linkable nodes to be recorded.
     expect(linkables.get(programLinkNode('programA'))).toEqual(node.program);
     expect(linkables.get(programLinkNode('programB'))).toEqual(node.additionalPrograms[0]);
-    expect(linkables.get(pdaLinkNode('pdaA'))).toEqual(node.program.pdas[0]);
-    expect(linkables.get(pdaLinkNode('pdaB'))).toEqual(node.additionalPrograms[0].pdas[0]);
-    expect(linkables.get(accountLinkNode('accountA'))).toEqual(node.program.accounts[0]);
-    expect(linkables.get(accountLinkNode('accountB'))).toEqual(node.additionalPrograms[0].accounts[0]);
-    expect(linkables.get(definedTypeLinkNode('typeA'))).toEqual(node.program.definedTypes[0]);
-    expect(linkables.get(definedTypeLinkNode('typeB'))).toEqual(node.additionalPrograms[0].definedTypes[0]);
+    expect(linkables.get(pdaLinkNode('pdaA', 'programA'))).toEqual(node.program.pdas[0]);
+    expect(linkables.get(pdaLinkNode('pdaB', 'programB'))).toEqual(node.additionalPrograms[0].pdas[0]);
+    expect(linkables.get(accountLinkNode('accountA', 'programA'))).toEqual(node.program.accounts[0]);
+    expect(linkables.get(accountLinkNode('accountB', 'programB'))).toEqual(node.additionalPrograms[0].accounts[0]);
+    expect(linkables.get(definedTypeLinkNode('typeA', 'programA'))).toEqual(node.program.definedTypes[0]);
+    expect(linkables.get(definedTypeLinkNode('typeB', 'programB'))).toEqual(node.additionalPrograms[0].definedTypes[0]);
 });
 
 test('it records all linkable before the first visit of the base visitor', () => {
@@ -75,4 +84,53 @@ test('it records all linkable before the first visit of the base visitor', () =>
 
     // Then we expect all linkable nodes to be recorded.
     expect(events).toEqual(['programA:true', 'programB:true']);
+});
+
+test('it keeps track of the current program when extending a visitor', () => {
+    // Given the following root node containing two program containing an account with the same name.
+    const programA = programNode({
+        accounts: [accountNode({ name: 'someAccount' })],
+        name: 'programA',
+        publicKey: '1111',
+    });
+    const programB = programNode({
+        accounts: [accountNode({ name: 'someAccount' })],
+        name: 'programB',
+        publicKey: '2222',
+    });
+    const node = rootNode(programA, [programB]);
+
+    // And a recordLinkablesVisitor extending a base visitor that checks
+    // the result of getting the linkable node with the same name for each program.
+    const linkables = new LinkableDictionary();
+    const dictionary: Record<string, AccountNode> = {};
+    const baseVisitor = interceptVisitor(voidVisitor(), (node, next) => {
+        if (isNode(node, 'programNode')) {
+            dictionary[node.name] = linkables.getOrThrow(accountLinkNode('someAccount'));
+        }
+        next(node);
+    });
+    const visitor = recordLinkablesVisitor(baseVisitor, linkables);
+
+    // When we visit the tree.
+    visit(node, visitor);
+
+    // Then we expect each program to have its own account.
+    expect(dictionary.programA).toBe(programA.accounts[0]);
+    expect(dictionary.programB).toBe(programB.accounts[0]);
+});
+
+test('it does not record linkable types that are not under a program node', () => {
+    // Given the following account node that is not under a program node.
+    const node = accountNode({ name: 'someAccount' });
+
+    // And a recordLinkablesVisitor extending a void visitor.
+    const linkables = new LinkableDictionary();
+    const visitor = recordLinkablesVisitor(voidVisitor(), linkables);
+
+    // When we visit the node.
+    visit(node, visitor);
+
+    // Then we expect the account node to not be recorded.
+    expect(linkables.has(accountLinkNode('someAccount'))).toBe(false);
 });

--- a/packages/visitors/src/unwrapDefinedTypesVisitor.ts
+++ b/packages/visitors/src/unwrapDefinedTypesVisitor.ts
@@ -16,7 +16,6 @@ export function unwrapDefinedTypesVisitor(typesToInline: string[] | '*' = '*') {
 
     return pipe(
         nonNullableIdentityVisitor(),
-        v => recordLinkablesVisitor(v, linkables),
         v =>
             extendVisitor(v, {
                 visitDefinedTypeLink(linkType, { self }) {
@@ -42,5 +41,6 @@ export function unwrapDefinedTypesVisitor(typesToInline: string[] | '*' = '*') {
                     });
                 },
             }),
+        v => recordLinkablesVisitor(v, linkables),
     );
 }

--- a/packages/visitors/test/fillDefaultPdaSeedValuesVisitor.test.ts
+++ b/packages/visitors/test/fillDefaultPdaSeedValuesVisitor.test.ts
@@ -10,6 +10,7 @@ import {
     pdaNode,
     pdaSeedValueNode,
     pdaValueNode,
+    programNode,
     publicKeyTypeNode,
     variablePdaSeedNode,
 } from '@kinobi-so/nodes';
@@ -20,17 +21,25 @@ import { fillDefaultPdaSeedValuesVisitor } from '../src';
 
 test('it fills missing pda seed values with default values', () => {
     // Given a pdaNode with three variable seeds.
-    const pda = pdaNode({
-        name: 'myPda',
-        seeds: [
-            variablePdaSeedNode('seed1', numberTypeNode('u64')),
-            variablePdaSeedNode('seed2', numberTypeNode('u64')),
-            variablePdaSeedNode('seed3', publicKeyTypeNode()),
+    const program = programNode({
+        name: 'myProgram',
+        pdas: [
+            pdaNode({
+                name: 'myPda',
+                seeds: [
+                    variablePdaSeedNode('seed1', numberTypeNode('u64')),
+                    variablePdaSeedNode('seed2', numberTypeNode('u64')),
+                    variablePdaSeedNode('seed3', publicKeyTypeNode()),
+                ],
+            }),
         ],
+        publicKey: '1111',
     });
+    const pda = program.pdas[0];
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
+    linkables.stack.push(program);
     linkables.record(pda);
 
     // And a pdaValueNode with a single seed filled.
@@ -64,17 +73,25 @@ test('it fills missing pda seed values with default values', () => {
 
 test('it fills nested pda value nodes', () => {
     // Given a pdaNode with three variable seeds.
-    const pda = pdaNode({
-        name: 'myPda',
-        seeds: [
-            variablePdaSeedNode('seed1', numberTypeNode('u64')),
-            variablePdaSeedNode('seed2', numberTypeNode('u64')),
-            variablePdaSeedNode('seed3', publicKeyTypeNode()),
+    const program = programNode({
+        name: 'myProgram',
+        pdas: [
+            pdaNode({
+                name: 'myPda',
+                seeds: [
+                    variablePdaSeedNode('seed1', numberTypeNode('u64')),
+                    variablePdaSeedNode('seed2', numberTypeNode('u64')),
+                    variablePdaSeedNode('seed3', publicKeyTypeNode()),
+                ],
+            }),
         ],
+        publicKey: '1111',
     });
+    const pda = program.pdas[0];
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
+    linkables.stack.push(program);
     linkables.record(pda);
 
     // And a pdaValueNode nested inside a conditionalValueNode.
@@ -114,17 +131,25 @@ test('it fills nested pda value nodes', () => {
 
 test('it ignores default seeds missing from the instruction', () => {
     // Given a pdaNode with three variable seeds.
-    const pda = pdaNode({
-        name: 'myPda',
-        seeds: [
-            variablePdaSeedNode('seed1', numberTypeNode('u64')),
-            variablePdaSeedNode('seed2', numberTypeNode('u64')),
-            variablePdaSeedNode('seed3', publicKeyTypeNode()),
+    const program = programNode({
+        name: 'myProgram',
+        pdas: [
+            pdaNode({
+                name: 'myPda',
+                seeds: [
+                    variablePdaSeedNode('seed1', numberTypeNode('u64')),
+                    variablePdaSeedNode('seed2', numberTypeNode('u64')),
+                    variablePdaSeedNode('seed3', publicKeyTypeNode()),
+                ],
+            }),
         ],
+        publicKey: '1111',
     });
+    const pda = program.pdas[0];
 
     // And a linkable dictionary that recorded this PDA.
     const linkables = new LinkableDictionary();
+    linkables.stack.push(program);
     linkables.record(pda);
 
     // And a pdaValueNode with a single seed filled.


### PR DESCRIPTION
This PR adds a new optional `program` attribute of type `ProgramLinkNode` to the other link nodes — i.e. `AccountLinkNode`, `DefinedTypeLinkNode` and `PdaLinkNode`.

This means, link nodes can now explicitly target another program instead of putting every linkable nodes within the same namespace, regardless of which program they belong to.

As such, the `LinkableDictionary` and the `recordLinkablesVisitor` have been updated to explicitly record linkable nodes and resolve link nodes from the program they belong to.

To illustrate all of that here's an example. Consider the following root node:

```ts
const programA = programNode({
  accounts: [accountNode({ name: 'accountA' })],
  definedTypes: [definedTypeNode({ name: 'someType', type: numberTypeNode('u32') })],
  name: 'programA',
  publicKey: '1111',
});
const programB = programNode({
  accounts: [accountNode({ name: 'accountB' })],
  definedTypes: [definedTypeNode({ name: 'someType', type: numberTypeNode('u64') })],
  name: 'programA',
  publicKey: '1111',
});
const node = rootNode(programA, [programB]);
```

As you can see, each program defines its own unique account (A and B) but they both use the same name `"someType"` for a defined type that has slightly different type definitions (u32 vs u64) based on the program.

Before this PR, recording the linkables inside that node would result in the shared type being overridden by the second program as they are not namespaced.

```ts
const linkables = new LinkableDictionary();
visit(node, recordLinkablesVisitor(baseVisitor, linkables));

linkables.get(accountLinkNode('accountA')); // -> programA.accounts[0]
linkables.get(accountLinkNode('accountB')); // -> programB.accounts[0]
linkables.get(definedTypeLinkNode('someType')); // -> programB.definedTypes[0]
```

After this PR, all recorded linkables are namespaced by the program they belong to. By default, it will use the program we are currently under when inside a visitor.

```ts
// Inside program A.
linkables.get(accountLinkNode('accountA')); // -> programA.accounts[0]
linkables.get(accountLinkNode('accountB')); // -> undefined
linkables.get(definedTypeLinkNode('someType')); // -> programA.definedTypes[0]

// Inside program B.
linkables.get(accountLinkNode('accountA')); // -> undefined
linkables.get(accountLinkNode('accountB')); // -> programB.accounts[0]
linkables.get(definedTypeLinkNode('someType')); // -> programB.definedTypes[0]
```

However, we can use the optional `program` attribute of the link node to point outside of the current program.

```ts
// Inside program A.
linkables.get(accountLinkNode('accountB', 'programB')); // -> programB.accounts[0]
linkables.get(definedTypeLinkNode('someType', 'programB')); // -> programB.definedTypes[0]
```

~~Additionally, if we are not inside a program — e.g. not inside a visitor — we can provide that information to the `LinkableDictionary` using the second argument of the `get` method~~. EDIT: I removed this part to simplify the API as it was not used currently in the codebase.
