### PR TITLE
[0.21] Fix TS bug on `accept` and `update` Kinobi functions

### DIFF
--- a/.changeset/two-swans-shake.md
+++ b/.changeset/two-swans-shake.md
@@ -1,0 +1,5 @@
+---
+'kinobi': patch
+---
+
+Fix TS bug on `accept` and `update` Kinobi function

--- a/packages/library/src/kinobi.ts
+++ b/packages/library/src/kinobi.ts
@@ -4,18 +4,18 @@ import { assertIsNode, KinobiVersion, Node, RootNode } from '@kinobi-so/nodes';
 import { visit, Visitor } from '@kinobi-so/visitors';
 
 export interface Kinobi {
-    accept<T>(visitor: Visitor<T>): T;
+    accept<T>(visitor: Visitor<T, 'rootNode'>): T;
     clone(): Kinobi;
     getJson(): string;
     getRoot(): RootNode;
-    update(visitor: Visitor<Node | null>): void;
+    update(visitor: Visitor<Node | null, 'rootNode'>): void;
 }
 
 export function createFromRoot(root: RootNode): Kinobi {
     let currentRoot = root;
     validateKinobiVersion(currentRoot.version);
     return {
-        accept<T>(visitor: Visitor<T>): T {
+        accept<T>(visitor: Visitor<T, 'rootNode'>): T {
             return visit(currentRoot, visitor);
         },
         clone(): Kinobi {
@@ -27,7 +27,7 @@ export function createFromRoot(root: RootNode): Kinobi {
         getRoot(): RootNode {
             return currentRoot;
         },
-        update(visitor: Visitor<Node | null>): void {
+        update(visitor: Visitor<Node | null, 'rootNode'>): void {
             const newRoot = visit(currentRoot, visitor);
             assertIsNode(newRoot, 'rootNode');
             currentRoot = newRoot;

--- a/packages/library/test/index.test.ts
+++ b/packages/library/test/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { identityVisitor, rootNode } from '../src';
+import { createFromRoot, identityVisitor, programNode, rootNode, rootNodeVisitor, voidVisitor } from '../src';
 
 test('it exports node helpers', () => {
     expect(typeof rootNode).toBe('function');
@@ -8,4 +8,18 @@ test('it exports node helpers', () => {
 
 test('it exports visitors', () => {
     expect(typeof identityVisitor).toBe('function');
+});
+
+test('it accepts visitors', () => {
+    const kinobi = createFromRoot(rootNode(programNode({ name: 'myProgram', publicKey: '1111' })));
+    const visitor = voidVisitor(['rootNode']);
+    const result = kinobi.accept(visitor) satisfies void;
+    expect(typeof result).toBe('undefined');
+});
+
+test('it updates the root node returned by visitors', () => {
+    const kinobi = createFromRoot(rootNode(programNode({ name: 'myProgram', publicKey: '1111' })));
+    const visitor = rootNodeVisitor(node => rootNode(programNode({ ...node.program, name: 'myTransformedProgram' })));
+    kinobi.update(visitor) satisfies void;
+    expect(kinobi.getRoot()).toEqual(rootNode(programNode({ name: 'myTransformedProgram', publicKey: '1111' })));
 });


### PR DESCRIPTION
This PR fixes the type expectations for the visitor argument of the `kinobi.accept` and `kinobi.update` functions.