### PR TITLE
[0.21] Fix a bug that reuses the same `ImportMap` in fragments

### DIFF
--- a/.changeset/giant-dogs-scream.md
+++ b/.changeset/giant-dogs-scream.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-js': patch
+---
+
+Fix a bug that reuses the same `ImportMap` within different code fragments

--- a/packages/renderers-js/src/fragments/common.ts
+++ b/packages/renderers-js/src/fragments/common.ts
@@ -7,7 +7,7 @@ import { ImportMap } from '../ImportMap';
 import { render } from '../utils';
 
 export function fragment(render: string, imports?: ImportMap): Fragment {
-    return new Fragment(render, imports ? new ImportMap().mergeWith(imports) : undefined);
+    return new Fragment(render, imports);
 }
 
 export function fragmentFromTemplate(fragmentFile: string, context?: object, options?: ConfigureOptions): Fragment {
@@ -31,8 +31,8 @@ export class Fragment {
 
     constructor(render: string, imports?: ImportMap, features?: Set<FragmentFeature>) {
         this.render = render;
-        this.imports = imports ?? new ImportMap();
-        this.features = features ?? new Set();
+        this.imports = imports ? new ImportMap().mergeWith(imports) : new ImportMap();
+        this.features = new Set([...(features ?? [])]);
     }
 
     setRender(render: string): this {

--- a/packages/renderers-js/src/fragments/common.ts
+++ b/packages/renderers-js/src/fragments/common.ts
@@ -7,7 +7,7 @@ import { ImportMap } from '../ImportMap';
 import { render } from '../utils';
 
 export function fragment(render: string, imports?: ImportMap): Fragment {
-    return new Fragment(render, imports);
+    return new Fragment(render, imports ? new ImportMap().mergeWith(imports) : undefined);
 }
 
 export function fragmentFromTemplate(fragmentFile: string, context?: object, options?: ConfigureOptions): Fragment {

--- a/packages/renderers-js/test/_setup.ts
+++ b/packages/renderers-js/test/_setup.ts
@@ -21,6 +21,15 @@ export function renderMapContains(renderMap: RenderMap, key: string, expected: (
     return codeContains(renderMap.get(key), expected);
 }
 
+export function renderMapDoesNotContain(
+    renderMap: RenderMap,
+    key: string,
+    expected: (RegExp | string)[] | RegExp | string,
+) {
+    expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
+    return codeDoesNotContain(renderMap.get(key), expected);
+}
+
 export async function codeContains(actual: string, expected: (RegExp | string)[] | RegExp | string) {
     const expectedArray = Array.isArray(expected) ? expected : [expected];
     const normalizedActual = await normalizeCode(actual);
@@ -50,6 +59,15 @@ export function renderMapContainsImports(renderMap: RenderMap, key: string, expe
     return codeContainsImports(renderMap.get(key), expectedImports);
 }
 
+export function renderMapDoesNotContainImports(
+    renderMap: RenderMap,
+    key: string,
+    expectedImports: Record<string, string[]>,
+) {
+    expect(renderMap.has(key), `RenderMap is missing key "${key}".`).toBe(true);
+    return codeDoesNotContainImports(renderMap.get(key), expectedImports);
+}
+
 export async function codeContainsImports(actual: string, expectedImports: Record<string, string[]>) {
     const normalizedActual = await inlineCode(actual);
     const importPairs = Object.entries(expectedImports).flatMap(([key, value]) => {
@@ -58,6 +76,17 @@ export async function codeContainsImports(actual: string, expectedImports: Recor
 
     importPairs.forEach(([importFrom, importValue]) => {
         expect(normalizedActual).toMatch(new RegExp(`import{[^}]*\\b${importValue}\\b[^}]*}from'${importFrom}'`));
+    });
+}
+
+export async function codeDoesNotContainImports(actual: string, expectedImports: Record<string, string[]>) {
+    const normalizedActual = await inlineCode(actual);
+    const importPairs = Object.entries(expectedImports).flatMap(([key, value]) => {
+        return value.map(v => [key, v] as const);
+    });
+
+    importPairs.forEach(([importFrom, importValue]) => {
+        expect(normalizedActual).not.toMatch(new RegExp(`import{[^}]*\\b${importValue}\\b[^}]*}from'${importFrom}'`));
     });
 }
 


### PR DESCRIPTION
Currently, if you pass the same `ImportMap` to two fragments using the `fragment` function, each of these separate fragments will reference the same `ImportMap` instance. This causes other bugs as, when we update the imports of one fragments, we end up updating the imports of another.

This PR fixes this by cloning the `ImportMap` when creating a new fragment.