### PR TITLE
[0.21] Add an optional programAddress override to instruction builders of JS renderer

### DIFF
--- a/.changeset/lovely-worms-rhyme.md
+++ b/.changeset/lovely-worms-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@kinobi-so/renderers-js': patch
+---
+
+Add an optional programAddress override to instruction builders

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/createGuard.ts
@@ -224,6 +224,7 @@ export async function getCreateGuardInstructionAsync<
   TAccountAssociatedTokenProgram extends string,
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: CreateGuardAsyncInput<
     TAccountGuard,
@@ -234,10 +235,11 @@ export async function getCreateGuardInstructionAsync<
     TAccountAssociatedTokenProgram,
     TAccountTokenProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   CreateGuardInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountGuard,
     TAccountMint,
     TAccountMintTokenAccount,
@@ -249,7 +251,8 @@ export async function getCreateGuardInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -336,7 +339,7 @@ export async function getCreateGuardInstructionAsync<
       args as CreateGuardInstructionDataArgs
     ),
   } as CreateGuardInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountGuard,
     TAccountMint,
     TAccountMintTokenAccount,
@@ -385,6 +388,7 @@ export function getCreateGuardInstruction<
   TAccountAssociatedTokenProgram extends string,
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: CreateGuardInput<
     TAccountGuard,
@@ -395,9 +399,10 @@ export function getCreateGuardInstruction<
     TAccountAssociatedTokenProgram,
     TAccountTokenProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateGuardInstruction<
-  typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountGuard,
   TAccountMint,
   TAccountMintTokenAccount,
@@ -408,7 +413,8 @@ export function getCreateGuardInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -466,7 +472,7 @@ export function getCreateGuardInstruction<
       args as CreateGuardInstructionDataArgs
     ),
   } as CreateGuardInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountGuard,
     TAccountMint,
     TAccountMintTokenAccount,

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/execute.ts
@@ -147,6 +147,7 @@ export async function getExecuteInstructionAsync<
   TAccountExtraMetasAccount extends string,
   TAccountGuard extends string,
   TAccountInstructionSysvarAccount extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: ExecuteAsyncInput<
     TAccountSourceAccount,
@@ -156,10 +157,11 @@ export async function getExecuteInstructionAsync<
     TAccountExtraMetasAccount,
     TAccountGuard,
     TAccountInstructionSysvarAccount
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   ExecuteInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSourceAccount,
     TAccountMint,
     TAccountDestinationAccount,
@@ -170,7 +172,8 @@ export async function getExecuteInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -235,7 +238,7 @@ export async function getExecuteInstructionAsync<
       args as ExecuteInstructionDataArgs
     ),
   } as ExecuteInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSourceAccount,
     TAccountMint,
     TAccountDestinationAccount,
@@ -275,6 +278,7 @@ export function getExecuteInstruction<
   TAccountExtraMetasAccount extends string,
   TAccountGuard extends string,
   TAccountInstructionSysvarAccount extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: ExecuteInput<
     TAccountSourceAccount,
@@ -284,9 +288,10 @@ export function getExecuteInstruction<
     TAccountExtraMetasAccount,
     TAccountGuard,
     TAccountInstructionSysvarAccount
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): ExecuteInstruction<
-  typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSourceAccount,
   TAccountMint,
   TAccountDestinationAccount,
@@ -296,7 +301,8 @@ export function getExecuteInstruction<
   TAccountInstructionSysvarAccount
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -347,7 +353,7 @@ export function getExecuteInstruction<
       args as ExecuteInstructionDataArgs
     ),
   } as ExecuteInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSourceAccount,
     TAccountMint,
     TAccountDestinationAccount,

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/initialize.ts
@@ -136,6 +136,7 @@ export async function getInitializeInstructionAsync<
   TAccountTransferHookAuthority extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: InitializeAsyncInput<
     TAccountExtraMetasAccount,
@@ -144,10 +145,11 @@ export async function getInitializeInstructionAsync<
     TAccountTransferHookAuthority,
     TAccountSystemProgram,
     TAccountPayer
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   InitializeInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountExtraMetasAccount,
     TAccountGuard,
     TAccountMint,
@@ -157,7 +159,8 @@ export async function getInitializeInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -212,7 +215,7 @@ export async function getInitializeInstructionAsync<
     programAddress,
     data: getInitializeInstructionDataEncoder().encode({}),
   } as InitializeInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountExtraMetasAccount,
     TAccountGuard,
     TAccountMint,
@@ -247,6 +250,7 @@ export function getInitializeInstruction<
   TAccountTransferHookAuthority extends string,
   TAccountSystemProgram extends string,
   TAccountPayer extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: InitializeInput<
     TAccountExtraMetasAccount,
@@ -255,9 +259,10 @@ export function getInitializeInstruction<
     TAccountTransferHookAuthority,
     TAccountSystemProgram,
     TAccountPayer
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeInstruction<
-  typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountExtraMetasAccount,
   TAccountGuard,
   TAccountMint,
@@ -266,7 +271,8 @@ export function getInitializeInstruction<
   TAccountPayer
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -307,7 +313,7 @@ export function getInitializeInstruction<
     programAddress,
     data: getInitializeInstructionDataEncoder().encode({}),
   } as InitializeInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountExtraMetasAccount,
     TAccountGuard,
     TAccountMint,

--- a/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
+++ b/packages/renderers-js/e2e/anchor/src/generated/instructions/updateGuard.ts
@@ -185,6 +185,7 @@ export async function getUpdateGuardInstructionAsync<
   TAccountGuardAuthority extends string,
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: UpdateGuardAsyncInput<
     TAccountGuard,
@@ -193,10 +194,11 @@ export async function getUpdateGuardInstructionAsync<
     TAccountGuardAuthority,
     TAccountTokenProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   UpdateGuardInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountGuard,
     TAccountMint,
     TAccountTokenAccount,
@@ -206,7 +208,8 @@ export async function getUpdateGuardInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -279,7 +282,7 @@ export async function getUpdateGuardInstructionAsync<
       args as UpdateGuardInstructionDataArgs
     ),
   } as UpdateGuardInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountGuard,
     TAccountMint,
     TAccountTokenAccount,
@@ -317,6 +320,7 @@ export function getUpdateGuardInstruction<
   TAccountGuardAuthority extends string,
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
 >(
   input: UpdateGuardInput<
     TAccountGuard,
@@ -325,9 +329,10 @@ export function getUpdateGuardInstruction<
     TAccountGuardAuthority,
     TAccountTokenProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): UpdateGuardInstruction<
-  typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountGuard,
   TAccountMint,
   TAccountTokenAccount,
@@ -336,7 +341,8 @@ export function getUpdateGuardInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? WEN_TRANSFER_GUARD_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -380,7 +386,7 @@ export function getUpdateGuardInstruction<
       args as UpdateGuardInstructionDataArgs
     ),
   } as UpdateGuardInstruction<
-    typeof WEN_TRANSFER_GUARD_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountGuard,
     TAccountMint,
     TAccountTokenAccount,

--- a/packages/renderers-js/e2e/memo/src/generated/instructions/addMemo.ts
+++ b/packages/renderers-js/e2e/memo/src/generated/instructions/addMemo.ts
@@ -59,11 +59,14 @@ export type AddMemoInput = {
   signers?: Array<TransactionSigner>;
 };
 
-export function getAddMemoInstruction(
-  input: AddMemoInput
-): AddMemoInstruction<typeof MEMO_PROGRAM_ADDRESS> {
+export function getAddMemoInstruction<
+  TProgramAddress extends Address = typeof MEMO_PROGRAM_ADDRESS,
+>(
+  input: AddMemoInput,
+  config?: { programAddress?: TProgramAddress }
+): AddMemoInstruction<TProgramAddress> {
   // Program address.
-  const programAddress = MEMO_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? MEMO_PROGRAM_ADDRESS;
 
   // Original args.
   const args = { ...input };
@@ -83,7 +86,7 @@ export function getAddMemoInstruction(
     data: getAddMemoInstructionDataEncoder().encode(
       args as AddMemoInstructionDataArgs
     ),
-  } as AddMemoInstruction<typeof MEMO_PROGRAM_ADDRESS>;
+  } as AddMemoInstruction<TProgramAddress>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/advanceNonceAccount.ts
@@ -104,20 +104,22 @@ export function getAdvanceNonceAccountInstruction<
   TAccountNonceAccount extends string,
   TAccountRecentBlockhashesSysvar extends string,
   TAccountNonceAuthority extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
   input: AdvanceNonceAccountInput<
     TAccountNonceAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountNonceAuthority
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): AdvanceNonceAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNonceAccount,
   TAccountRecentBlockhashesSysvar,
   TAccountNonceAuthority
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -149,7 +151,7 @@ export function getAdvanceNonceAccountInstruction<
     programAddress,
     data: getAdvanceNonceAccountInstructionDataEncoder().encode({}),
   } as AdvanceNonceAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNonceAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountNonceAuthority

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocate.ts
@@ -88,11 +88,15 @@ export type AllocateInput<TAccountNewAccount extends string = string> = {
   space: AllocateInstructionDataArgs['space'];
 };
 
-export function getAllocateInstruction<TAccountNewAccount extends string>(
-  input: AllocateInput<TAccountNewAccount>
-): AllocateInstruction<typeof SYSTEM_PROGRAM_ADDRESS, TAccountNewAccount> {
+export function getAllocateInstruction<
+  TAccountNewAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+>(
+  input: AllocateInput<TAccountNewAccount>,
+  config?: { programAddress?: TProgramAddress }
+): AllocateInstruction<TProgramAddress, TAccountNewAccount> {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -113,7 +117,7 @@ export function getAllocateInstruction<TAccountNewAccount extends string>(
     data: getAllocateInstructionDataEncoder().encode(
       args as AllocateInstructionDataArgs
     ),
-  } as AllocateInstruction<typeof SYSTEM_PROGRAM_ADDRESS, TAccountNewAccount>;
+  } as AllocateInstruction<TProgramAddress, TAccountNewAccount>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/allocateWithSeed.ts
@@ -126,15 +126,17 @@ export type AllocateWithSeedInput<
 export function getAllocateWithSeedInstruction<
   TAccountNewAccount extends string,
   TAccountBaseAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AllocateWithSeedInput<TAccountNewAccount, TAccountBaseAccount>
+  input: AllocateWithSeedInput<TAccountNewAccount, TAccountBaseAccount>,
+  config?: { programAddress?: TProgramAddress }
 ): AllocateWithSeedInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNewAccount,
   TAccountBaseAccount
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -160,7 +162,7 @@ export function getAllocateWithSeedInstruction<
       args as AllocateWithSeedInstructionDataArgs
     ),
   } as AllocateWithSeedInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNewAccount,
     TAccountBaseAccount
   >;

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assign.ts
@@ -91,11 +91,15 @@ export type AssignInput<TAccountAccount extends string = string> = {
   programAddress: AssignInstructionDataArgs['programAddress'];
 };
 
-export function getAssignInstruction<TAccountAccount extends string>(
-  input: AssignInput<TAccountAccount>
-): AssignInstruction<typeof SYSTEM_PROGRAM_ADDRESS, TAccountAccount> {
+export function getAssignInstruction<
+  TAccountAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
+>(
+  input: AssignInput<TAccountAccount>,
+  config?: { programAddress?: TProgramAddress }
+): AssignInstruction<TProgramAddress, TAccountAccount> {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -116,7 +120,7 @@ export function getAssignInstruction<TAccountAccount extends string>(
     data: getAssignInstructionDataEncoder().encode(
       args as AssignInstructionDataArgs
     ),
-  } as AssignInstruction<typeof SYSTEM_PROGRAM_ADDRESS, TAccountAccount>;
+  } as AssignInstruction<TProgramAddress, TAccountAccount>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/assignWithSeed.ts
@@ -119,15 +119,17 @@ export type AssignWithSeedInput<
 export function getAssignWithSeedInstruction<
   TAccountAccount extends string,
   TAccountBaseAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: AssignWithSeedInput<TAccountAccount, TAccountBaseAccount>
+  input: AssignWithSeedInput<TAccountAccount, TAccountBaseAccount>,
+  config?: { programAddress?: TProgramAddress }
 ): AssignWithSeedInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountBaseAccount
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -153,7 +155,7 @@ export function getAssignWithSeedInstruction<
       args as AssignWithSeedInstructionDataArgs
     ),
   } as AssignWithSeedInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountBaseAccount
   >;

--- a/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/authorizeNonceAccount.ts
@@ -108,18 +108,20 @@ export type AuthorizeNonceAccountInput<
 export function getAuthorizeNonceAccountInstruction<
   TAccountNonceAccount extends string,
   TAccountNonceAuthority extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
   input: AuthorizeNonceAccountInput<
     TAccountNonceAccount,
     TAccountNonceAuthority
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): AuthorizeNonceAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNonceAccount,
   TAccountNonceAuthority
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -145,7 +147,7 @@ export function getAuthorizeNonceAccountInstruction<
       args as AuthorizeNonceAccountInstructionDataArgs
     ),
   } as AuthorizeNonceAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNonceAccount,
     TAccountNonceAuthority
   >;

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccount.ts
@@ -125,16 +125,18 @@ export type CreateAccountInput<
 export function getCreateAccountInstruction<
   TAccountPayer extends string,
   TAccountNewAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: CreateAccountInput<TAccountPayer, TAccountNewAccount>
+  input: CreateAccountInput<TAccountPayer, TAccountNewAccount>,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountNewAccount
 > &
   IInstructionWithByteDelta {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -166,7 +168,7 @@ export function getCreateAccountInstruction<
       args as CreateAccountInstructionDataArgs
     ),
   } as CreateAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountNewAccount
   >;

--- a/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/createAccountWithSeed.ts
@@ -143,20 +143,22 @@ export function getCreateAccountWithSeedInstruction<
   TAccountPayer extends string,
   TAccountNewAccount extends string,
   TAccountBaseAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
   input: CreateAccountWithSeedInput<
     TAccountPayer,
     TAccountNewAccount,
     TAccountBaseAccount
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAccountWithSeedInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountNewAccount,
   TAccountBaseAccount
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -184,7 +186,7 @@ export function getCreateAccountWithSeedInstruction<
       args as CreateAccountWithSeedInstructionDataArgs
     ),
   } as CreateAccountWithSeedInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountNewAccount,
     TAccountBaseAccount

--- a/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/initializeNonceAccount.ts
@@ -116,20 +116,22 @@ export function getInitializeNonceAccountInstruction<
   TAccountNonceAccount extends string,
   TAccountRecentBlockhashesSysvar extends string,
   TAccountRentSysvar extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
   input: InitializeNonceAccountInput<
     TAccountNonceAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountRentSysvar
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeNonceAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNonceAccount,
   TAccountRecentBlockhashesSysvar,
   TAccountRentSysvar
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -170,7 +172,7 @@ export function getInitializeNonceAccountInstruction<
       args as InitializeNonceAccountInstructionDataArgs
     ),
   } as InitializeNonceAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNonceAccount,
     TAccountRecentBlockhashesSysvar,
     TAccountRentSysvar

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSol.ts
@@ -103,15 +103,17 @@ export type TransferSolInput<
 export function getTransferSolInstruction<
   TAccountSource extends string,
   TAccountDestination extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: TransferSolInput<TAccountSource, TAccountDestination>
+  input: TransferSolInput<TAccountSource, TAccountDestination>,
+  config?: { programAddress?: TProgramAddress }
 ): TransferSolInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountDestination
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -137,7 +139,7 @@ export function getTransferSolInstruction<
       args as TransferSolInstructionDataArgs
     ),
   } as TransferSolInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountDestination
   >;

--- a/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/transferSolWithSeed.ts
@@ -131,20 +131,22 @@ export function getTransferSolWithSeedInstruction<
   TAccountSource extends string,
   TAccountBaseAccount extends string,
   TAccountDestination extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
   input: TransferSolWithSeedInput<
     TAccountSource,
     TAccountBaseAccount,
     TAccountDestination
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): TransferSolWithSeedInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountBaseAccount,
   TAccountDestination
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -172,7 +174,7 @@ export function getTransferSolWithSeedInstruction<
       args as TransferSolWithSeedInstructionDataArgs
     ),
   } as TransferSolWithSeedInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountBaseAccount,
     TAccountDestination

--- a/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/upgradeNonceAccount.ts
@@ -83,14 +83,13 @@ export type UpgradeNonceAccountInput<
 
 export function getUpgradeNonceAccountInstruction<
   TAccountNonceAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: UpgradeNonceAccountInput<TAccountNonceAccount>
-): UpgradeNonceAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
-  TAccountNonceAccount
-> {
+  input: UpgradeNonceAccountInput<TAccountNonceAccount>,
+  config?: { programAddress?: TProgramAddress }
+): UpgradeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount> {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -106,10 +105,7 @@ export function getUpgradeNonceAccountInstruction<
     accounts: [getAccountMeta(accounts.nonceAccount)],
     programAddress,
     data: getUpgradeNonceAccountInstructionDataEncoder().encode({}),
-  } as UpgradeNonceAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
-    TAccountNonceAccount
-  >;
+  } as UpgradeNonceAccountInstruction<TProgramAddress, TAccountNonceAccount>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
+++ b/packages/renderers-js/e2e/system/src/generated/instructions/withdrawNonceAccount.ts
@@ -134,6 +134,7 @@ export function getWithdrawNonceAccountInstruction<
   TAccountRecentBlockhashesSysvar extends string,
   TAccountRentSysvar extends string,
   TAccountNonceAuthority extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
   input: WithdrawNonceAccountInput<
     TAccountNonceAccount,
@@ -141,9 +142,10 @@ export function getWithdrawNonceAccountInstruction<
     TAccountRecentBlockhashesSysvar,
     TAccountRentSysvar,
     TAccountNonceAuthority
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): WithdrawNonceAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNonceAccount,
   TAccountRecipientAccount,
   TAccountRecentBlockhashesSysvar,
@@ -151,7 +153,7 @@ export function getWithdrawNonceAccountInstruction<
   TAccountNonceAuthority
 > {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -199,7 +201,7 @@ export function getWithdrawNonceAccountInstruction<
       args as WithdrawNonceAccountInstructionDataArgs
     ),
   } as WithdrawNonceAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNonceAccount,
     TAccountRecipientAccount,
     TAccountRecentBlockhashesSysvar,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/amountToUiAmount.ts
@@ -93,11 +93,15 @@ export type AmountToUiAmountInput<TAccountMint extends string = string> = {
   amount: AmountToUiAmountInstructionDataArgs['amount'];
 };
 
-export function getAmountToUiAmountInstruction<TAccountMint extends string>(
-  input: AmountToUiAmountInput<TAccountMint>
-): AmountToUiAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getAmountToUiAmountInstruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: AmountToUiAmountInput<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): AmountToUiAmountInstruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -118,7 +122,7 @@ export function getAmountToUiAmountInstruction<TAccountMint extends string>(
     data: getAmountToUiAmountInstructionDataEncoder().encode(
       args as AmountToUiAmountInstructionDataArgs
     ),
-  } as AmountToUiAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint>;
+  } as AmountToUiAmountInstruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approve.ts
@@ -119,10 +119,12 @@ export function getApproveInstruction<
   TAccountSource extends string,
   TAccountDelegate extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ApproveInput<TAccountSource, TAccountDelegate, TAccountOwner>
+  input: ApproveInput<TAccountSource, TAccountDelegate, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): ApproveInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountDelegate,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -130,7 +132,7 @@ export function getApproveInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -168,7 +170,7 @@ export function getApproveInstruction<
       args as ApproveInstructionDataArgs
     ),
   } as ApproveInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountDelegate,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/approveChecked.ts
@@ -134,15 +134,17 @@ export function getApproveCheckedInstruction<
   TAccountMint extends string,
   TAccountDelegate extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
   input: ApproveCheckedInput<
     TAccountSource,
     TAccountMint,
     TAccountDelegate,
     TAccountOwner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): ApproveCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountMint,
   TAccountDelegate,
@@ -151,7 +153,7 @@ export function getApproveCheckedInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -191,7 +193,7 @@ export function getApproveCheckedInstruction<
       args as ApproveCheckedInstructionDataArgs
     ),
   } as ApproveCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountMint,
     TAccountDelegate,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burn.ts
@@ -116,10 +116,12 @@ export function getBurnInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: BurnInput<TAccountAccount, TAccountMint, TAccountAuthority>
+  input: BurnInput<TAccountAccount, TAccountMint, TAccountAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): BurnInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
@@ -128,7 +130,7 @@ export function getBurnInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -166,7 +168,7 @@ export function getBurnInstruction<
       args as BurnInstructionDataArgs
     ),
   } as BurnInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/burnChecked.ts
@@ -126,10 +126,12 @@ export function getBurnCheckedInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: BurnCheckedInput<TAccountAccount, TAccountMint, TAccountAuthority>
+  input: BurnCheckedInput<TAccountAccount, TAccountMint, TAccountAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): BurnCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
@@ -138,7 +140,7 @@ export function getBurnCheckedInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -176,7 +178,7 @@ export function getBurnCheckedInstruction<
       args as BurnCheckedInstructionDataArgs
     ),
   } as BurnCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/closeAccount.ts
@@ -103,10 +103,12 @@ export function getCloseAccountInstruction<
   TAccountAccount extends string,
   TAccountDestination extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: CloseAccountInput<TAccountAccount, TAccountDestination, TAccountOwner>
+  input: CloseAccountInput<TAccountAccount, TAccountDestination, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): CloseAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountDestination,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -114,7 +116,7 @@ export function getCloseAccountInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -150,7 +152,7 @@ export function getCloseAccountInstruction<
     programAddress,
     data: getCloseAccountInstructionDataEncoder().encode({}),
   } as CloseAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountDestination,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAccount.ts
@@ -125,16 +125,18 @@ export type CreateAccountInput<
 export function getCreateAccountInstruction<
   TAccountPayer extends string,
   TAccountNewAccount extends string,
+  TProgramAddress extends Address = typeof SYSTEM_PROGRAM_ADDRESS,
 >(
-  input: CreateAccountInput<TAccountPayer, TAccountNewAccount>
+  input: CreateAccountInput<TAccountPayer, TAccountNewAccount>,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAccountInstruction<
-  typeof SYSTEM_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountNewAccount
 > &
   IInstructionWithByteDelta {
   // Program address.
-  const programAddress = SYSTEM_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? SYSTEM_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -166,7 +168,7 @@ export function getCreateAccountInstruction<
       args as CreateAccountInstructionDataArgs
     ),
   } as CreateAccountInstruction<
-    typeof SYSTEM_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountNewAccount
   >;

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedToken.ts
@@ -136,6 +136,7 @@ export async function getCreateAssociatedTokenInstructionAsync<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenAsyncInput<
     TAccountPayer,
@@ -144,10 +145,11 @@ export async function getCreateAssociatedTokenInstructionAsync<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   CreateAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -157,7 +159,8 @@ export async function getCreateAssociatedTokenInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -203,7 +206,7 @@ export async function getCreateAssociatedTokenInstructionAsync<
     programAddress,
     data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -244,6 +247,7 @@ export function getCreateAssociatedTokenInstruction<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenInput<
     TAccountPayer,
@@ -252,9 +256,10 @@ export function getCreateAssociatedTokenInstruction<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAssociatedTokenInstruction<
-  typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountAta,
   TAccountOwner,
@@ -263,7 +268,8 @@ export function getCreateAssociatedTokenInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -302,7 +308,7 @@ export function getCreateAssociatedTokenInstruction<
     programAddress,
     data: getCreateAssociatedTokenInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -140,6 +140,7 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenIdempotentAsyncInput<
     TAccountPayer,
@@ -148,10 +149,11 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   CreateAssociatedTokenIdempotentInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -161,7 +163,8 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -207,7 +210,7 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
     programAddress,
     data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenIdempotentInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,
@@ -248,6 +251,7 @@ export function getCreateAssociatedTokenIdempotentInstruction<
   TAccountMint extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: CreateAssociatedTokenIdempotentInput<
     TAccountPayer,
@@ -256,9 +260,10 @@ export function getCreateAssociatedTokenIdempotentInstruction<
     TAccountMint,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateAssociatedTokenIdempotentInstruction<
-  typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountPayer,
   TAccountAta,
   TAccountOwner,
@@ -267,7 +272,8 @@ export function getCreateAssociatedTokenIdempotentInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -306,7 +312,7 @@ export function getCreateAssociatedTokenIdempotentInstruction<
     programAddress,
     data: getCreateAssociatedTokenIdempotentInstructionDataEncoder().encode({}),
   } as CreateAssociatedTokenIdempotentInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountPayer,
     TAccountAta,
     TAccountOwner,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/freezeAccount.ts
@@ -103,10 +103,12 @@ export function getFreezeAccountInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: FreezeAccountInput<TAccountAccount, TAccountMint, TAccountOwner>
+  input: FreezeAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): FreezeAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -114,7 +116,7 @@ export function getFreezeAccountInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -150,7 +152,7 @@ export function getFreezeAccountInstruction<
     programAddress,
     data: getFreezeAccountInstructionDataEncoder().encode({}),
   } as FreezeAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/getAccountDataSize.ts
@@ -80,11 +80,15 @@ export type GetAccountDataSizeInput<TAccountMint extends string = string> = {
   mint: Address<TAccountMint>;
 };
 
-export function getGetAccountDataSizeInstruction<TAccountMint extends string>(
-  input: GetAccountDataSizeInput<TAccountMint>
-): GetAccountDataSizeInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getGetAccountDataSizeInstruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: GetAccountDataSizeInput<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): GetAccountDataSizeInstruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -100,10 +104,7 @@ export function getGetAccountDataSizeInstruction<TAccountMint extends string>(
     accounts: [getAccountMeta(accounts.mint)],
     programAddress,
     data: getGetAccountDataSizeInstructionDataEncoder().encode({}),
-  } as GetAccountDataSizeInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountMint
-  >;
+  } as GetAccountDataSizeInstruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount.ts
@@ -108,22 +108,24 @@ export function getInitializeAccountInstruction<
   TAccountMint extends string,
   TAccountOwner extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
   input: InitializeAccountInput<
     TAccountAccount,
     TAccountMint,
     TAccountOwner,
     TAccountRent
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   TAccountOwner,
   TAccountRent
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -154,7 +156,7 @@ export function getInitializeAccountInstruction<
     programAddress,
     data: getInitializeAccountInstructionDataEncoder().encode({}),
   } as InitializeAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     TAccountOwner,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount2.ts
@@ -116,16 +116,18 @@ export function getInitializeAccount2Instruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccount2Input<TAccountAccount, TAccountMint, TAccountRent>
+  input: InitializeAccount2Input<TAccountAccount, TAccountMint, TAccountRent>,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeAccount2Instruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   TAccountRent
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -159,7 +161,7 @@ export function getInitializeAccount2Instruction<
       args as InitializeAccount2InstructionDataArgs
     ),
   } as InitializeAccount2Instruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     TAccountRent

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeAccount3.ts
@@ -106,15 +106,17 @@ export type InitializeAccount3Input<
 export function getInitializeAccount3Instruction<
   TAccountAccount extends string,
   TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeAccount3Input<TAccountAccount, TAccountMint>
+  input: InitializeAccount3Input<TAccountAccount, TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeAccount3Instruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -137,7 +139,7 @@ export function getInitializeAccount3Instruction<
       args as InitializeAccount3InstructionDataArgs
     ),
   } as InitializeAccount3Instruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint
   >;

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeImmutableOwner.ts
@@ -84,14 +84,13 @@ export type InitializeImmutableOwnerInput<
 
 export function getInitializeImmutableOwnerInstruction<
   TAccountAccount extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeImmutableOwnerInput<TAccountAccount>
-): InitializeImmutableOwnerInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountAccount
-> {
+  input: InitializeImmutableOwnerInput<TAccountAccount>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -107,10 +106,7 @@ export function getInitializeImmutableOwnerInstruction<
     accounts: [getAccountMeta(accounts.account)],
     programAddress,
     data: getInitializeImmutableOwnerInstructionDataEncoder().encode({}),
-  } as InitializeImmutableOwnerInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountAccount
-  >;
+  } as InitializeImmutableOwnerInstruction<TProgramAddress, TAccountAccount>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint.ts
@@ -131,15 +131,13 @@ export type InitializeMintInput<
 export function getInitializeMintInstruction<
   TAccountMint extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMintInput<TAccountMint, TAccountRent>
-): InitializeMintInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMint,
-  TAccountRent
-> {
+  input: InitializeMintInput<TAccountMint, TAccountRent>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -167,11 +165,7 @@ export function getInitializeMintInstruction<
     data: getInitializeMintInstructionDataEncoder().encode(
       args as InitializeMintInstructionDataArgs
     ),
-  } as InitializeMintInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountMint,
-    TAccountRent
-  >;
+  } as InitializeMintInstruction<TProgramAddress, TAccountMint, TAccountRent>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMint2.ts
@@ -116,11 +116,15 @@ export type InitializeMint2Input<TAccountMint extends string = string> = {
   freezeAuthority?: InitializeMint2InstructionDataArgs['freezeAuthority'];
 };
 
-export function getInitializeMint2Instruction<TAccountMint extends string>(
-  input: InitializeMint2Input<TAccountMint>
-): InitializeMint2Instruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getInitializeMint2Instruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: InitializeMint2Input<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeMint2Instruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -141,7 +145,7 @@ export function getInitializeMint2Instruction<TAccountMint extends string>(
     data: getInitializeMint2InstructionDataEncoder().encode(
       args as InitializeMint2InstructionDataArgs
     ),
-  } as InitializeMint2Instruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint>;
+  } as InitializeMint2Instruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig.ts
@@ -108,15 +108,17 @@ export type InitializeMultisigInput<
 export function getInitializeMultisigInstruction<
   TAccountMultisig extends string,
   TAccountRent extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMultisigInput<TAccountMultisig, TAccountRent>
+  input: InitializeMultisigInput<TAccountMultisig, TAccountRent>,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeMultisigInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountMultisig,
   TAccountRent
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -155,7 +157,7 @@ export function getInitializeMultisigInstruction<
       args as InitializeMultisigInstructionDataArgs
     ),
   } as InitializeMultisigInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountMultisig,
     TAccountRent
   >;

--- a/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/initializeMultisig2.ts
@@ -96,14 +96,13 @@ export type InitializeMultisig2Input<TAccountMultisig extends string = string> =
 
 export function getInitializeMultisig2Instruction<
   TAccountMultisig extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: InitializeMultisig2Input<TAccountMultisig>
-): InitializeMultisig2Instruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
-  TAccountMultisig
-> {
+  input: InitializeMultisig2Input<TAccountMultisig>,
+  config?: { programAddress?: TProgramAddress }
+): InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -130,10 +129,7 @@ export function getInitializeMultisig2Instruction<
     data: getInitializeMultisig2InstructionDataEncoder().encode(
       args as InitializeMultisig2InstructionDataArgs
     ),
-  } as InitializeMultisig2Instruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
-    TAccountMultisig
-  >;
+  } as InitializeMultisig2Instruction<TProgramAddress, TAccountMultisig>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintTo.ts
@@ -121,10 +121,12 @@ export function getMintToInstruction<
   TAccountMint extends string,
   TAccountToken extends string,
   TAccountMintAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: MintToInput<TAccountMint, TAccountToken, TAccountMintAuthority>
+  input: MintToInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): MintToInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountMint,
   TAccountToken,
   (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
@@ -133,7 +135,7 @@ export function getMintToInstruction<
     : TAccountMintAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -171,7 +173,7 @@ export function getMintToInstruction<
       args as MintToInstructionDataArgs
     ),
   } as MintToInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountMint,
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/mintToChecked.ts
@@ -128,10 +128,12 @@ export function getMintToCheckedInstruction<
   TAccountMint extends string,
   TAccountToken extends string,
   TAccountMintAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: MintToCheckedInput<TAccountMint, TAccountToken, TAccountMintAuthority>
+  input: MintToCheckedInput<TAccountMint, TAccountToken, TAccountMintAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): MintToCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountMint,
   TAccountToken,
   (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>
@@ -140,7 +142,7 @@ export function getMintToCheckedInstruction<
     : TAccountMintAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -178,7 +180,7 @@ export function getMintToCheckedInstruction<
       args as MintToCheckedInstructionDataArgs
     ),
   } as MintToCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountMint,
     TAccountToken,
     (typeof input)['mintAuthority'] extends TransactionSigner<TAccountMintAuthority>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -152,6 +152,7 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
   TAccountOwnerTokenMintAddress extends string,
   TAccountWalletAddress extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: RecoverNestedAssociatedTokenAsyncInput<
     TAccountNestedAssociatedAccountAddress,
@@ -161,10 +162,11 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
     TAccountOwnerTokenMintAddress,
     TAccountWalletAddress,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): Promise<
   RecoverNestedAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
     TAccountDestinationAssociatedAccountAddress,
@@ -175,7 +177,8 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
   >
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -252,7 +255,7 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
     programAddress,
     data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
   } as RecoverNestedAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
     TAccountDestinationAssociatedAccountAddress,
@@ -298,6 +301,7 @@ export function getRecoverNestedAssociatedTokenInstruction<
   TAccountOwnerTokenMintAddress extends string,
   TAccountWalletAddress extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
 >(
   input: RecoverNestedAssociatedTokenInput<
     TAccountNestedAssociatedAccountAddress,
@@ -307,9 +311,10 @@ export function getRecoverNestedAssociatedTokenInstruction<
     TAccountOwnerTokenMintAddress,
     TAccountWalletAddress,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): RecoverNestedAssociatedTokenInstruction<
-  typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNestedAssociatedAccountAddress,
   TAccountNestedTokenMintAddress,
   TAccountDestinationAssociatedAccountAddress,
@@ -319,7 +324,8 @@ export function getRecoverNestedAssociatedTokenInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? ASSOCIATED_TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -371,7 +377,7 @@ export function getRecoverNestedAssociatedTokenInstruction<
     programAddress,
     data: getRecoverNestedAssociatedTokenInstructionDataEncoder().encode({}),
   } as RecoverNestedAssociatedTokenInstruction<
-    typeof ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNestedAssociatedAccountAddress,
     TAccountNestedTokenMintAddress,
     TAccountDestinationAssociatedAccountAddress,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/revoke.ts
@@ -95,17 +95,19 @@ export type RevokeInput<
 export function getRevokeInstruction<
   TAccountSource extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: RevokeInput<TAccountSource, TAccountOwner>
+  input: RevokeInput<TAccountSource, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): RevokeInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
     ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -139,7 +141,7 @@ export function getRevokeInstruction<
     programAddress,
     data: getRevokeInstructionDataEncoder().encode({}),
   } as RevokeInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
       ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/setAuthority.ts
@@ -128,17 +128,19 @@ export type SetAuthorityInput<
 export function getSetAuthorityInstruction<
   TAccountOwned extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: SetAuthorityInput<TAccountOwned, TAccountOwner>
+  input: SetAuthorityInput<TAccountOwned, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): SetAuthorityInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountOwned,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
     ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -174,7 +176,7 @@ export function getSetAuthorityInstruction<
       args as SetAuthorityInstructionDataArgs
     ),
   } as SetAuthorityInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountOwned,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
       ? ReadonlySignerAccount<TAccountOwner> & IAccountSignerMeta<TAccountOwner>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/syncNative.ts
@@ -77,11 +77,15 @@ export type SyncNativeInput<TAccountAccount extends string = string> = {
   account: Address<TAccountAccount>;
 };
 
-export function getSyncNativeInstruction<TAccountAccount extends string>(
-  input: SyncNativeInput<TAccountAccount>
-): SyncNativeInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountAccount> {
+export function getSyncNativeInstruction<
+  TAccountAccount extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: SyncNativeInput<TAccountAccount>,
+  config?: { programAddress?: TProgramAddress }
+): SyncNativeInstruction<TProgramAddress, TAccountAccount> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -97,7 +101,7 @@ export function getSyncNativeInstruction<TAccountAccount extends string>(
     accounts: [getAccountMeta(accounts.account)],
     programAddress,
     data: getSyncNativeInstructionDataEncoder().encode({}),
-  } as SyncNativeInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountAccount>;
+  } as SyncNativeInstruction<TProgramAddress, TAccountAccount>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/thawAccount.ts
@@ -103,10 +103,12 @@ export function getThawAccountInstruction<
   TAccountAccount extends string,
   TAccountMint extends string,
   TAccountOwner extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: ThawAccountInput<TAccountAccount, TAccountMint, TAccountOwner>
+  input: ThawAccountInput<TAccountAccount, TAccountMint, TAccountOwner>,
+  config?: { programAddress?: TProgramAddress }
 ): ThawAccountInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountAccount,
   TAccountMint,
   (typeof input)['owner'] extends TransactionSigner<TAccountOwner>
@@ -114,7 +116,7 @@ export function getThawAccountInstruction<
     : TAccountOwner
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -150,7 +152,7 @@ export function getThawAccountInstruction<
     programAddress,
     data: getThawAccountInstructionDataEncoder().encode({}),
   } as ThawAccountInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountAccount,
     TAccountMint,
     (typeof input)['owner'] extends TransactionSigner<TAccountOwner>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transfer.ts
@@ -119,10 +119,12 @@ export function getTransferInstruction<
   TAccountSource extends string,
   TAccountDestination extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
-  input: TransferInput<TAccountSource, TAccountDestination, TAccountAuthority>
+  input: TransferInput<TAccountSource, TAccountDestination, TAccountAuthority>,
+  config?: { programAddress?: TProgramAddress }
 ): TransferInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountDestination,
   (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>
@@ -131,7 +133,7 @@ export function getTransferInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -169,7 +171,7 @@ export function getTransferInstruction<
       args as TransferInstructionDataArgs
     ),
   } as TransferInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountDestination,
     (typeof input)['authority'] extends TransactionSigner<TAccountAuthority>

--- a/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/transferChecked.ts
@@ -134,15 +134,17 @@ export function getTransferCheckedInstruction<
   TAccountMint extends string,
   TAccountDestination extends string,
   TAccountAuthority extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
 >(
   input: TransferCheckedInput<
     TAccountSource,
     TAccountMint,
     TAccountDestination,
     TAccountAuthority
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): TransferCheckedInstruction<
-  typeof TOKEN_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountSource,
   TAccountMint,
   TAccountDestination,
@@ -152,7 +154,7 @@ export function getTransferCheckedInstruction<
     : TAccountAuthority
 > {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -192,7 +194,7 @@ export function getTransferCheckedInstruction<
       args as TransferCheckedInstructionDataArgs
     ),
   } as TransferCheckedInstruction<
-    typeof TOKEN_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountSource,
     TAccountMint,
     TAccountDestination,

--- a/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
+++ b/packages/renderers-js/e2e/token/src/generated/instructions/uiAmountToAmount.ts
@@ -93,11 +93,15 @@ export type UiAmountToAmountInput<TAccountMint extends string = string> = {
   uiAmount: UiAmountToAmountInstructionDataArgs['uiAmount'];
 };
 
-export function getUiAmountToAmountInstruction<TAccountMint extends string>(
-  input: UiAmountToAmountInput<TAccountMint>
-): UiAmountToAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint> {
+export function getUiAmountToAmountInstruction<
+  TAccountMint extends string,
+  TProgramAddress extends Address = typeof TOKEN_PROGRAM_ADDRESS,
+>(
+  input: UiAmountToAmountInput<TAccountMint>,
+  config?: { programAddress?: TProgramAddress }
+): UiAmountToAmountInstruction<TProgramAddress, TAccountMint> {
   // Program address.
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? TOKEN_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -118,7 +122,7 @@ export function getUiAmountToAmountInstruction<TAccountMint extends string>(
     data: getUiAmountToAmountInstructionDataEncoder().encode(
       args as UiAmountToAmountInstructionDataArgs
     ),
-  } as UiAmountToAmountInstruction<typeof TOKEN_PROGRAM_ADDRESS, TAccountMint>;
+  } as UiAmountToAmountInstruction<TProgramAddress, TAccountMint>;
 
   return instruction;
 }

--- a/packages/renderers-js/e2e/token/test/programAddressOverride.test.ts
+++ b/packages/renderers-js/e2e/token/test/programAddressOverride.test.ts
@@ -1,0 +1,28 @@
+import { address, generateKeyPairSigner } from '@solana/web3.js';
+import test from 'ava';
+import { getInitializeMintInstruction } from '../src/index.js';
+
+test('it can override the program address of an instruction', async (t) => {
+  // Note: this test does not need to run the generated instruction
+
+  // Given: a program address that we want to create instructions for
+  const TOKEN_22_PROGRAM_ADDRESS = address(
+    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+  );
+
+  // When we generate an initialize mint instruction with the program address
+  const mintAddress = (await generateKeyPairSigner()).address;
+  const mintAuthorityAddress = (await generateKeyPairSigner()).address;
+
+  const mintInstruction = getInitializeMintInstruction(
+    {
+      mint: mintAddress,
+      decimals: 2,
+      mintAuthority: mintAuthorityAddress,
+    },
+    { programAddress: TOKEN_22_PROGRAM_ADDRESS }
+  );
+
+  // Then: the generated instruction has the correct program address
+  t.is(mintInstruction.programAddress, TOKEN_22_PROGRAM_ADDRESS);
+});

--- a/packages/renderers-js/public/templates/fragments/instructionFunction.njk
+++ b/packages/renderers-js/public/templates/fragments/instructionFunction.njk
@@ -1,8 +1,8 @@
 {{ inputTypeFragment }}
 
-export {{ 'async' if useAsync }} function {{ functionName }}{{ typeParamsFragment }}(input: {{ inputTypeCallFragment }}): {{ getReturnType(instructionTypeFragment) }} {
+export {{ 'async' if useAsync }} function {{ functionName }}{{ typeParamsFragment }}(input: {{ inputTypeCallFragment }}, config?: { programAddress?: TProgramAddress } ): {{ getReturnType(instructionTypeFragment) }} {
   // Program address.
-  const programAddress = {{ programAddressConstant }};
+  const programAddress = config?.programAddress ?? {{ programAddressConstant }};
 
   {% if hasAccounts %}
     // Original accounts.

--- a/packages/renderers-js/test/instructionsPage.test.ts
+++ b/packages/renderers-js/test/instructionsPage.test.ts
@@ -397,3 +397,27 @@ test('it can override the import of a resolver value node', async () => {
         someModule: ['myResolver'],
     });
 });
+
+test('it renders optional config that can override the program address', async () => {
+    // Given the following instruction
+    const node = programNode({
+        instructions: [
+            instructionNode({
+                accounts: [],
+                name: 'myInstruction',
+            }),
+        ],
+        name: 'myProgram',
+        publicKey: '1111',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then we expect an optional config parameter with an optional programAddress field
+    // And we expect this to be used to override programAddress if it is set
+    await renderMapContains(renderMap, 'instructions/myInstruction.ts', [
+        'config?: { programAddress?: TProgramAddress }',
+        'programAddress = config?.programAddress ?? MY_PROGRAM_PROGRAM_ADDRESS',
+    ]);
+});


### PR DESCRIPTION
Currently when an instruction creator is called, it hardcodes the `programAddress` part of the program to the program that the client is being rendered for. This PR adds a new optional `config` parameter to instruction creators, which can be used to override the `programAddress`. For example:

```ts
import {
    getTransferCheckedInstruction,
} from '@solana-program/token';

const sendTokenInstruction = getTransferCheckedInstruction({
    source,
    destination,
    amount,
    authority,
   decimals,
   mint,
  }, { programAddress: TOKEN_22_PROGRAM_ADDRESS }
);
```

This is useful when there are multiple programs with compatible instructions, for example in the case of token and token22. In these cases, when dealing with these compatible instructions, you can now re-use the `token` client and just change the `programAddress` of the generated instructions.